### PR TITLE
GTT additions

### DIFF
--- a/plugins/L1TableProducer.cc
+++ b/plugins/L1TableProducer.cc
@@ -3,5 +3,9 @@
 #include "DataFormats/L1Trigger/interface/VertexWord.h"
 typedef SimpleFlatTableProducer<l1t::VertexWord> SimpleL1VtxWordCandidateFlatTableProducer;
 
+#include "DataFormats/L1Trigger/interface/TkJetWord.h"
+typedef SimpleFlatTableProducer<l1t::TkJetWord> SimpleL1TkJetWordCandidateFlatTableProducer;
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleL1VtxWordCandidateFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleL1TkJetWordCandidateFlatTableProducer);

--- a/python/l1Ph2Nano_cff.py
+++ b/python/l1Ph2Nano_cff.py
@@ -75,7 +75,66 @@ vtxTable = cms.EDProducer(
     singleton = cms.bool(False), # the number of entries is variable
     variables = cms.PSet(
         z0 = Var("z0()",float, doc = "primary vertex position z coordinate"),
-        sumPt = Var("pt()",float, doc = "sum pt of tracks")
+        sumPt = Var("pt()",float, doc = "sum pt of tracks"),
+        hwValid = Var("validBits()",bool, doc = "hardware vertex valid bit"),
+        hwZ0 = Var("z0Bits()",int, doc = "hardware z0 vertex position"),
+        # hwNTracksIn = Var("multiplicityBits()",int, doc = "hardware track multiplicity in the vertex"), # Currently not filled in emulation or firmware
+        hwPt = Var("ptBits()",int,doc="hardware pt"), # This value seems to be essentially (uint)pt(), but there should be 2 float bits (0.25GeV granularity) represented here... is to_uint() truncating the float bits?
+        # hwQual = Var("qualityBits()",int,doc="hardware qual"), # Currently not filled in emulation or firmware
+        # hwNTracksOut = Var("inverseMultiplicityBits()",int, doc = "hardware track multiplicity out of the vertex"), # Currently not filled in emulation or firmware
+     )
+ )
+
+gttTrackJetsTable = cms.EDProducer(
+    "SimpleL1TkJetWordCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    src = cms.InputTag("l1tTrackJetsEmulation","L1TrackJets"),
+    name = cms.string("L1TrackJet"),
+    doc = cms.string("GTT Track Jets"),
+    singleton = cms.bool(False), # the number of entries is variable
+    variables = cms.PSet(
+        pt = Var("pt()", float, doc="pt"),
+        eta = Var("glbeta()", float, doc="eta"),
+        phi = Var("glbphi()", float, doc="phi"),
+        z0 = Var("z0()", float, doc="z0"), #Jet z0 is now always 0, however?
+        hwPt = Var("ptBits()", int, doc="hardware pt"),
+        hwEta = Var("glbPhiBits()", int, doc="hardware eta"),
+        hwPhi = Var("glbEtaBits()", int, doc="hardware eta"),
+        hwZ0 = Var("z0Bits()", int, doc="hardware z0"), #Jet z0 is now always 0, however?
+        hwNTracks = Var("ntBits()", int, doc="hardware number of tracks"),
+        hwNDisplacedTracks = Var("ntBits()", int, doc="hardware number of tracks"),
+    )
+)
+
+gttEtSumTable = cms.EDProducer(
+    "SimpleCandidateFlatTableProducer",
+    src = cms.InputTag("l1tTrackerEmuEtMiss", "L1TrackerEmuEtMiss"),
+    name = cms.string("L1TrackMET"),
+    doc = cms.string("GTT Track MET"),
+    singleton = cms.bool(True), # the number of entries is variable
+    variables = cms.PSet(
+        # pt = Var("pt", float, doc="MET pt"),
+        # phi = Var("phi", float, doc="MET phi"),
+        # hwValid = Var("hwQual() > 0",int, doc = "hardware Missing Et valid bit"),
+        hwValid = Var("hwQual()",bool, doc = "hardware Missing Et valid bit"),
+        # hwVectorSumPt = Var("Et().range()", int, doc = "hardware Missing Et vector sum"),
+        hwPhi = Var("hwPhi", int, doc = "hardware Missing Et phi"),
+    )
+)
+
+gttHtSumTable = cms.EDProducer(
+    "SimpleCandidateFlatTableProducer",
+    src = cms.InputTag("l1tTrackerEmuHTMiss", "L1TrackerEmuHTMiss"),
+    name = cms.string("L1TrackHT"),
+    doc = cms.string("GTT Track Missing HT"),
+    singleton = cms.bool(True), # the number of entries is variable
+    variables = cms.PSet(
+        hwValid = Var("hwQual()",bool, doc = "hardware Track MHT valid bit"),
+        hwPhi = Var("hwPhi()", int, doc = "hardware Track MHT phi"),
+        hwPt = Var("hwPt()", int, doc = "hardware Track HT"),
+        # mht = Var("pt", float, doc="MHT pt"),
+        # mhtPhi = Var("phi", float, doc="MHT phi"),
+        ht = Var(f"p4().energy()", float, doc="HT"),
     )
 )
 
@@ -453,6 +512,13 @@ nnTauTable = cms.EDProducer(
     )
 )
 
+## GTT Track Objects (except Vertices)
+p2GTTL1TablesTask = cms.Task(
+    gttEtSumTable,
+    gttHtSumTable,
+    gttTrackJetsTable,
+)
+
 ## GT objects
 p2GTL1TablesTask = cms.Task(
     gtTkPhoTable,
@@ -495,7 +561,7 @@ p2L1TablesTask = cms.Task(
 
 # ## Add GT ntuple to L1Task
 p2L1TablesTask.add(p2GTL1TablesTask)
-
+p2L1TablesTask.add(p2GTTL1TablesTask)
 
 # ## FOR GT vs L1 COMPARISON we order the tables like below
 # p2L1TablesTask = cms.Task(

--- a/test/GTTValidation.py
+++ b/test/GTTValidation.py
@@ -1,0 +1,36 @@
+import uproot
+import awkward as ak
+import hist
+
+
+forig = uproot.open("L1Ph2Nano_noMod100evts.root")
+torig = forig["Events"]
+f = uproot.open("L1Ph2Nano.root")
+t = f["Events"]
+
+new_branches = list(set(t.keys()) - set(torig.keys()))
+new_branches.sort()
+print("Additional Branches:", new_branches)
+
+potential_arrays = ['L1Vertex_hwNTracksIn', 'L1Vertex_hwNTracksOut', 'L1Vertex_hwPt', 'L1Vertex_hwQual', 'L1Vertex_hwValid', 'L1Vertex_hwZ0', 'L1Vertex_sumPt', 'L1Vertex_z0']
+arrs = t.arrays([b for b in potential_arrays if b in t.keys()])
+print("L1Vertex fields:", arrs.fields)
+#['L1Vertex_hwNTracksIn', 'L1Vertex_hwNTracksOut', 'L1Vertex_hwPt', 'L1Vertex_hwQual', 'L1Vertex_hwValid', 'L1Vertex_hwZ0', 'L1Vertex_sumPt', 'L1Vertex_z0']
+assert ak.min(arrs.L1Vertex_hwValid) == 1 and ak.max(arrs.L1Vertex_hwValid) == 1, "hwValid bit is not giving the expected value of always 1"
+assert ak.min(arrs.L1Vertex_hwPt) >= 0, "SumPt for vertices is less than zero"
+assert ak.max(arrs.L1Vertex_hwPt) < 2**10, "(hw) SumPt for vertices exceeds the maximum specified in the interface doc"
+if "L1Vertex_hwQual" in t.keys():
+    assert ak.min(arrs.L1Vertex_hwQual) == ak.max(arrs.L1Vertex_hwQual), "hwQual has non-Zero value, update the test if this part of the word is now filled"
+if "L1Vertex_hwNTracksIn" in t.keys():
+    assert ak.min(arrs.L1Vertex_hwNTracksIn) == ak.max(arrs.L1Vertex_hwNTracksIn), "hwNTracksIn has non-Zero value, update the test if this part of the word is now filled"
+if "L1Vertex_hwNTracksOut" in t.keys():
+    assert ak.min(arrs.L1Vertex_hwNTracksOut) == ak.max(arrs.L1Vertex_hwNTracksOut), "hwNTracksIn has non-Zero value, update the test if this part of the word is now filled"
+print("L1Vertex hwZ0 interpretation wrong, will need to fill with properly signed int")
+# >>> ak.max(arrs.L1Vertex_hwZ0)
+# 13
+# >>> ak.min(arrs.L1Vertex_hwZ0)
+# -2147483648
+# >>> ak.min(arrs.L1Vertex_z0)
+# -14.824219
+# >>> ak.max(arrs.L1Vertex_z0)
+# 13.880859


### PR DESCRIPTION
This draft PR starts some GTT extensions/additions to the L1Nano format, from some exploration a few weeks ago and re-testing things now. As of now, this is incomplete, and could use person-power in GTT to extend it more usefully, and decide on what's worth putting in now/later (e.g. see Vertex nTracksIn/Out: can be uncommented now, but we don't fill these in the VertexWord yet)

1. hw values for Vertices are added. Most values match current expectations (nTracksIn/Out are not filled, but the lines can be uncommented to add them if these hw values are desirable)
2. Vertex hwZ0 interpretation is wrong, would need to be filled to ensure signed-int value works as expected
3. Vertex hwSumPt interpretation seems to be the integer cast of the float value stored. Expectation was a factor ~4 difference, to account for the 2 float bits from the ap_fixed<12,10> being accounted for, but it looks like truncation or the float sumPt is getting the wrong value by a factor 4 too large.
4. FlatTableProducer for TkJets is added. A few test values are filled, but no validation is done
5. Et and Ht sums are added with partial fills. More work would be needed to finish filling what's currently written in the link data (see https://github.com/cms-sw/cmssw/blob/master/L1Trigger/DemonstratorTools/src/codecs_htsums.cc, https://github.com/cms-sw/cmssw/blob/master/L1Trigger/DemonstratorTools/src/codecs_etsums.cc). These are currently in the least-interfaceable state, as much of the logic is in codecs rather than in the Object classes. This is a big(ger) problem to be solved, and would need some person-power and/or cross-talk on approach in correlator
6. Whether hwValues are valuable additions to the format depends on use-cases, customizability, size constraints, etc. Storing the entire Word as long unsigned int would only work directly for vertices and sums (64 bits), Jets are encoded as 2 64-bit words (latter currently unfilled according to interface docs). This would also necessitate some interpretation machinery in e.g. a coffea schema or some utility functions (not out of the realm of possibility, but does make it a barrier to easy usage, so not pursued in this initial foray)

A GTTValidation script is added which does a few nigh-trivial tests of Vertices and checks for what branches have been successfully added to the nano format (presumes you create a few-event file with the current master configuration and append the postfix indicated by the 'forig' file open near the top). When things are complete, it could be left as an example or deleted to clean things up.

