### PR TITLE
Move to 140X release L1Nano

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,11 @@ NanoAOD ntupler for Phase-2 L1 Objects
 
 ## Setup
 
-Tested under latest CMSSW_13_3 pre-release: `CMSSW_13_3_0_pre4`:
+Tested under latest CMSSW_14_0 pre-release: `CMSSW_14_0_0_pre3`:
 
 ```bash
-cmsrel CMSSW_13_3_0_pre4
-cd CMSSW_13_3_0_pre4/src
-git cms-checkout-topic -u p2l1-gtEmulator:phase2-l1t-integration-13_3_0_pre3 #latest P2GT PR: https://github.com/cms-l1t-offline/cmssw/pull/1183
-git cms-rebase-topic -u artlbv:CMSSW_13_3_X_FixP2GT_HW_access # getting fix for P2GT HW access/conversion to int
-## eventually remove the tkJet sequence from the L1Sim step: 
+cmsrel CMSSW_14_0_0_pre3
+cd CMSSW_14_0_0_pre3/src
 git clone git@github.com:cms-l1-dpg/Phase2-L1Nano.git PhysicsTools/L1Nano
 scram b -j 8
 ```
@@ -21,24 +18,29 @@ scram b -j 8
 
 In the `test` directory there is a `cmsRun` config to rerun the L1 trigger + the P2GT emulator and produce the nano ntuple from these outputs.
 
-Usage: `cmsRun rerunL1_133_Nano_cfg.py`
+Usage: `cmsRun rerunL1_140pre3_Nano_cfg.py`
 
 ### Via cmsDriver
 
 One can append the L1Nano output to the `cmsDriver` command via this customisation: 
 ```bash
+--eventcontent NANOAOD
 -s USER:PhysicsTools/L1Nano/l1tPh2Nano_cff.l1tPh2NanoTask --customise PhysicsTools/L1Nano/l1tPh2Nano_cff.addFullPh2L1Nano
 ```
 
 Example command (w/o P2GT yet, pending https://github.com/cms-sw/cmssw/pull/43210 ):
 ```bash
-cmsDriver.py reL1Nano --conditions 125X_mcRun4_realistic_v2 -n 2 --era Phase2C17I13M9 --eventcontent NANOAOD -s RAW2DIGI,L1,NANO --datatier GEN-SIM-DIGI-RAW-MINIAOD --fileout file:test.root --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2.addHcalTriggerPrimitives,L1Trigger/Configuration/customisePhase2FEVTDEBUGHLT.customisePhase2FEVTDEBUGHLT --geometry Extended2026D88 --nThreads 1 --filein file:/eos/cms/store/mc/Phase2Spring23DIGIRECOMiniAOD/VBFHToInvisible_M-125_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_131X_mcRun4_realistic_v5-v1/2520000/0294bad4-867c-43c9-850f-4beaef783e39.root --mc --inputCommands='keep *, drop l1tPFJets_*_*_*' --outputCommands='keep *P2GT*_*_*_*, drop l1tPFJets_*_*_*' --python_filename rerunL1_only_cfg_NANO.py --no_exec -s USER:PhysicsTools/L1Nano/l1tPh2Nano_cff.l1tPh2NanoTask --customise PhysicsTools/L1Nano/l1tPh2Nano_cff.addFullPh2L1Nano
+cmsDriver.py step1 --conditions 131X_mcRun4_realistic_v9 -n 2 --era Phase2C17I13M9 --eventcontent NANOAOD -s RAW2DIGI,L1,L1P2GT,USER:PhysicsTools/L1Nano/l1tPh2Nano_cff.l1tPh2NanoTask --datatier GEN-SIM-DIGI-RAW-MINIAOD --fileout file:test.root --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2.addHcalTriggerPrimitives,PhysicsTools/L1Nano/l1tPh2Nano_cff.addFullPh2L1Nano --geometry Extended2026D95 --nThreads 8 --filein /store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/005bc30b-cf79-4b3b-9ec1-a80e13072afd.root --mc --inputCommands="keep *, drop l1tPFJets_*_*_*" --outputCommands="drop l1tPFJets_*_*_*"
 ```
 
 
 ## Output
 
-The output file is a nanoAOD file with the output branches in the `Events` tree:
+The output file is a nanoAOD file with the output branches in the `Events` tree.
+
+An overview of the corresponding content is shown here: https://alobanov.web.cern.ch/L1T/Phase2/L1Nano/l1menu_nano_14X_doc_report.html
+
+Size report: https://alobanov.web.cern.ch/L1T/Phase2/L1Nano/l1menu_nano_14X_size_report.html
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ One can append the L1Nano output to the `cmsDriver` command via this customisati
 -s USER:PhysicsTools/L1Nano/l1tPh2Nano_cff.l1tPh2NanoTask --customise PhysicsTools/L1Nano/l1tPh2Nano_cff.addFullPh2L1Nano
 ```
 
-Example command (w/o P2GT yet, pending https://github.com/cms-sw/cmssw/pull/43210 ):
+Example command (w/o Track Trigger, based on [the 1400pre2 recipe from the Offline SW twiki](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TPhase2Instructions#Running_the_Emulator_For_par_AN1)):
 ```bash
 cmsDriver.py step1 --conditions 131X_mcRun4_realistic_v9 -n 2 --era Phase2C17I13M9 --eventcontent NANOAOD -s RAW2DIGI,L1,L1P2GT,USER:PhysicsTools/L1Nano/l1tPh2Nano_cff.l1tPh2NanoTask --datatier GEN-SIM-DIGI-RAW-MINIAOD --fileout file:test.root --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2.addHcalTriggerPrimitives,PhysicsTools/L1Nano/l1tPh2Nano_cff.addFullPh2L1Nano --geometry Extended2026D95 --nThreads 8 --filein /store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/005bc30b-cf79-4b3b-9ec1-a80e13072afd.root --mc --inputCommands="keep *, drop l1tPFJets_*_*_*" --outputCommands="drop l1tPFJets_*_*_*"
 ```

--- a/python/l1tPh2Nano_cff.py
+++ b/python/l1tPh2Nano_cff.py
@@ -49,9 +49,13 @@ def addGenObjects(process):
     process.l1tPh2NanoTask.add(
                 puTable, metMCTable,
                 genParticleTask, genParticleTablesTask,
-                genJetTable, patJetPartonsNano,genJetFlavourAssociation, genJetFlavourTable,
                 genTauTask,
     )
+    
+    # add all GenJets: AK4 and AK8
+    process.l1tPh2NanoTask.add(genJetTable,patJetPartonsNano,genJetFlavourTable)
+    process.l1tPh2NanoTask.add(genJetAK8Table,genJetAK8FlavourAssociation,genJetAK8FlavourTable)
+
     return process
 
 def addFullPh2L1Nano(process):

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -168,7 +168,7 @@ gmtTkMuTable = staMuTable.clone(
 ### Jets
 scJetTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
-    src = cms.InputTag('l1tSCPFL1PuppiCorrectedEmulator'),
+    src = cms.InputTag('l1tSC4PFL1PuppiCorrectedEmulator'),
     cut = cms.string(""),
     name = cms.string("L1scJet"),
     doc = cms.string("SeededCone 0.4 Puppi jet"),
@@ -181,7 +181,7 @@ scJetTable = cms.EDProducer(
 )
 
 scExtJetTable = scJetTable.clone(
-    src = cms.InputTag('l1tSCPFL1PuppiExtendedCorrectedEmulator'),
+    src = cms.InputTag('l1tSC4PFL1PuppiExtendedCorrectedEmulator'),
     name = cms.string("L1scExtJet"),
     doc = cms.string("SeededCone 0.4 Puppi jet from extended Puppi"),
     externalVariables = cms.PSet(
@@ -218,7 +218,7 @@ puppiMetTable = cms.EDProducer(
 
 seededConeSumsTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
-    src = cms.InputTag("l1tSCPFL1PuppiCorrectedEmulatorMHT",""),
+    src = cms.InputTag("l1tSC4PFL1PuppiCorrectedEmulatorMHT",""),
     name = cms.string("L1scJetSum"),
     doc = cms.string("HT and MHT from SeededCone jets; idx 0 is HT, idx 1 is MHT"),
     singleton = cms.bool(False), # the number of entries is variable

--- a/test/rerunL1_140pre3_Nano_cfg.py
+++ b/test/rerunL1_140pre3_Nano_cfg.py
@@ -1,0 +1,193 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: step1 --conditions 131X_mcRun4_realistic_v9 -n 2 --era Phase2C17I13M9 --eventcontent NANOAOD -s RAW2DIGI,L1,L1P2GT,USER:PhysicsTools/L1Nano/l1tPh2Nano_cff.l1tPh2NanoTask --datatier GEN-SIM-DIGI-RAW-MINIAOD --fileout file:test.root --customise PhysicsTools/L1Nano/l1tPh2Nano_cff.addFullPh2L1Nano --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2.addHcalTriggerPrimitives --geometry Extended2026D95 --nThreads 8 --filein /store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/005bc30b-cf79-4b3b-9ec1-a80e13072afd.root --mc --inputCommands=keep *, drop l1tPFJets_*_*_* --outputCommands=drop l1tPFJets_*_*_*
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+
+process = cms.Process('L1',Phase2C17I13M9)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D95Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.SimPhase2L1GlobalTriggerEmulator_cff')
+process.load('L1Trigger.Configuration.Phase2GTMenus.SeedDefinitions.prototypeSeeds')
+process.load('PhysicsTools.L1Nano.l1tPh2Nano_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    dropDescendantsOfDroppedBranches = cms.untracked.bool(False),
+    fileNames = cms.untracked.vstring('/store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/005bc30b-cf79-4b3b-9ec1-a80e13072afd.root'),
+    inputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop l1tPFJets_*_*_*'
+    ),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    TryToContinue = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    holdsReferencesToDeleteEarly = cms.untracked.VPSet(),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    modulesToCallForTryToContinue = cms.untracked.vstring(),
+    modulesToIgnoreForDeleteEarly = cms.untracked.vstring(),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step1 nevts:2'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+process.NANOAODoutput = cms.OutputModule("NanoAODOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(9),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('NANOAOD'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('l1nano.root'),
+    fakeNameForCrab = cms.untracked.bool(True),
+    outputCommands = process.NANOAODEventContent.outputCommands
+)
+
+# process.NANOAODoutput = cms.OutputModule("NanoAODOutputModule",
+#     compressionAlgorithm = cms.untracked.string('LZMA'),
+#     compressionLevel = cms.untracked.int32(9),
+#     dataset = cms.untracked.PSet(
+#         dataTier = cms.untracked.string('NANOAOD'),
+#         filterName = cms.untracked.string('')
+#     ),
+#     fileName = cms.untracked.string('file:l1nano.root'),
+#     fakeNameForCrab = cms.untracked.bool(True),
+#     outputCommands = process.NANOAODEventContent.outputCommands,
+# )
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '131X_mcRun4_realistic_v9', '')
+process.NANOAODoutput.outputCommands.append('drop l1tPFJets_*_*_*')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1simulation_step = cms.Path(process.SimL1Emulator)
+process.Phase2L1GTProducer = cms.Path(process.l1tGTProducerSequence)
+process.Phase2L1GTAlgoBlockProducer = cms.Path(process.l1tGTAlgoBlockProducerSequence)
+process.pDoubleEGEle37_24 = cms.Path(process.DoubleEGEle3724)
+process.pDoubleIsoTkPho22_12 = cms.Path(process.DoubleIsoTkPho2212)
+process.pDoublePuppiTau52_52 = cms.Path(process.DoublePuppiTau5252)
+process.pDoubleTkEle25_12 = cms.Path(process.DoubleTkEle2512)
+process.pDoubleTkMuon15_7 = cms.Path(process.DoubleTkMuon157)
+process.pIsoTkEleEGEle22_12 = cms.Path(process.IsoTkEleEGEle2212)
+process.pPuppiHT400 = cms.Path(process.PuppiHT400)
+process.pPuppiHT450 = cms.Path(process.PuppiHT450)
+process.pPuppiMET200 = cms.Path(process.PuppiMET200)
+process.pQuadJet70_55_40_40 = cms.Path(process.QuadJet70554040)
+process.pSingleEGEle51 = cms.Path(process.SingleEGEle51)
+process.pSingleIsoTkEle28 = cms.Path(process.SingleIsoTkEle28)
+process.pSingleIsoTkPho36 = cms.Path(process.SingleIsoTkPho36)
+process.pSinglePuppiJet230 = cms.Path(process.SinglePuppiJet230)
+process.pSingleTkEle36 = cms.Path(process.SingleTkEle36)
+process.pSingleTkMuon22 = cms.Path(process.SingleTkMuon22)
+process.pTripleTkMuon5_3_3 = cms.Path(process.TripleTkMuon533)
+process.l1ph2nano_step = cms.Path(process.l1tPh2NanoTask)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.NANOAODoutput_step = cms.EndPath(process.NANOAODoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(
+    process.raw2digi_step,
+    process.L1simulation_step,
+    process.Phase2L1GTProducer,process.Phase2L1GTAlgoBlockProducer,
+    process.pDoubleEGEle37_24,process.pDoubleIsoTkPho22_12,process.pDoublePuppiTau52_52,process.pDoubleTkEle25_12,process.pDoubleTkMuon15_7,process.pIsoTkEleEGEle22_12,process.pPuppiHT400,process.pPuppiHT450,process.pPuppiMET200,process.pQuadJet70_55_40_40,process.pSingleEGEle51,process.pSingleIsoTkEle28,process.pSingleIsoTkPho36,process.pSinglePuppiJet230,process.pSingleTkEle36,process.pSingleTkMuon22,process.pTripleTkMuon5_3_3,
+    # nano step
+    process.l1ph2nano_step,
+    process.endjob_step,
+    process.NANOAODoutput_step
+)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+#Setup FWK for multithreaded
+process.options.numberOfThreads = 1
+process.options.numberOfStreams = 1
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from PhysicsTools.L1Nano.l1tPh2Nano_cff
+from PhysicsTools.L1Nano.l1tPh2Nano_cff import addFullPh2L1Nano 
+
+#call to customisation function addFullPh2L1Nano imported from PhysicsTools.L1Nano.l1tPh2Nano_cff
+process = addFullPh2L1Nano(process)
+
+# Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.aging
+from SLHCUpgradeSimulations.Configuration.aging import customise_aging_1000 
+
+#call to customisation function customise_aging_1000 imported from SLHCUpgradeSimulations.Configuration.aging
+process = customise_aging_1000(process)
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.Utils
+from Configuration.DataProcessing.Utils import addMonitoring 
+
+#call to customisation function addMonitoring imported from Configuration.DataProcessing.Utils
+process = addMonitoring(process)
+
+# Automatic addition of the customisation function from L1Trigger.Configuration.customisePhase2
+from L1Trigger.Configuration.customisePhase2 import addHcalTriggerPrimitives 
+
+#call to customisation function addHcalTriggerPrimitives imported from L1Trigger.Configuration.customisePhase2
+process = addHcalTriggerPrimitives(process)
+
+# End of customisation functions
+
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion


### PR DESCRIPTION
This is in preparation for the Annual Review this spring.

* Update README for `CMSSW_14_0_0_pre3` and add corresponding test config
* Renamed many jet labels e.g. `L1scPuppiJet` -> `L1puppiJetSC4`
* Added SC8 jets