### PR TITLE
Tau and ML MET collections

### DIFF
--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -202,7 +202,7 @@ histoJetTable = sc4JetTable.clone(
 
 
 caloJetTable = sc4JetTable.clone(
-    src = cms.InputTag("l1tCaloJet","L1CaloJetCollectionBXV"),
+    src = cms.InputTag("l1tPhase2CaloJetEmulator","GCTJet"),
     name = cms.string("L1caloJet"),
     doc = cms.string("Calo Jets, origin: GCT"),
     cut = cms.string("pt > 30"), ## increase this to save space
@@ -245,13 +245,31 @@ histoSumsTable = sc4SumsTable.clone(
 ### Taus
 caloTauTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
-    src = cms.InputTag("l1tCaloJet","L1CaloTauCollectionBXV"),
+    src = cms.InputTag("l1tPhase2CaloJetEmulator","GCTJet"),
     cut = cms.string("pt > 20"),
     name = cms.string("L1caloTau"),
     doc = cms.string("Calo Taus"),
     singleton = cms.bool(False), # the number of entries is variable
     variables = cms.PSet(
+        et  = Var("tauEt",  float, precision=l1_float_precision_),
+        phi = Var("phi", float, precision=l1_float_precision_),
+        eta = Var("eta", float, precision=l1_float_precision_),
+    )
+)
+
+
+
+nnCaloTauTable = cms.EDProducer(
+    "SimpleCandidateFlatTableProducer",
+    src = cms.InputTag("l1tNNCaloTauEmulator","L1NNCaloTauCollectionBXV"),
+    cut = cms.string("pt > 20"),
+    name = cms.string("L1nnCaloTau"),
+    doc = cms.string("NN Calo Taus"),
+    singleton = cms.bool(False), # the number of entries is variable
+    variables = cms.PSet(
         l1P3Vars,
+        hwQual = Var("hwQual",int,doc="Tau ID working point, 90% --> 3, 95% --> 2, 99% --> 1, anything else --> 0"),
+        hwIso = Var("hwIso",int,doc="Tau ID * 10E4")
     )
 )
 
@@ -281,6 +299,18 @@ nnTauTable = cms.EDProducer(
     )
 )
 
+hpsTauTable = cms.EDProducer(
+    "SimpleCandidateFlatTableProducer",
+    src = cms.InputTag("l1HPSPFTauEmuProducer","HPSTaus"),
+    cut = cms.string(""),
+    name = cms.string("L1hpsTau"),
+    doc = cms.string("HPS Taus"),
+    singleton = cms.bool(False), # the number of entries is variable
+    variables = cms.PSet(
+        l1P3Vars
+    )
+)
+
 ## L1 Objects
 p2L1TablesTask = cms.Task(
     ## Muons
@@ -303,7 +333,9 @@ p2L1TablesTask = cms.Task(
     histoSumsTable,
     # taus
     caloTauTable,
+    nnCaloTauTable,
     nnTauTable,
+    hpsTauTable,
     # GTT
     vtxTable,
     pvtxTable,

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -285,8 +285,8 @@ nnTauTable = cms.EDProducer(
         charge = Var("charge", int),
         z0 = Var("z0", float, "vertex z0"),                
         ## copy paste from old menu ntuple https://github.com/artlbv/cmssw/blob/from-CMSSW_12_5_2_patch1/L1Trigger/L1TNtuples/src/L1AnalysisPhaseIIStep1.cc#L543C1-L555C1
-        chargedIso = Var("chargedIso", int),
-        fullIso = Var("fullIso", int),
+        chargedIso = Var("chargedIso", float),
+        fullIso = Var("fullIso", float),
         id = Var("id", int),
         passLooseNN = Var("passLooseNN", int),
         passLoosePF = Var("passLoosePF", int),

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -285,12 +285,12 @@ nnCaloTauTable = cms.EDProducer(
     )
 )
 
-nnTauTable = cms.EDProducer(
+nnPuppiTauTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
     src = cms.InputTag("l1tNNTauProducerPuppi","L1PFTausNN"),
     cut = cms.string(""),
-    name = cms.string("L1nnTau"),
-    doc = cms.string("NN Taus"),
+    name = cms.string("L1nnPuppiTau"),
+    doc = cms.string("NN Puppi Taus"),
     singleton = cms.bool(False), # the number of entries is variable
     variables = cms.PSet(
         l1P3Vars,
@@ -347,7 +347,7 @@ p2L1TablesTask = cms.Task(
     # taus
     caloTauTable,
     nnCaloTauTable,
-    nnTauTable,
+    nnPuppiTauTable,
     hpsTauTable,
     # GTT
     vtxTable,

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -251,7 +251,7 @@ caloTauTable = cms.EDProducer(
     doc = cms.string("Calo Taus"),
     singleton = cms.bool(False), # the number of entries is variable
     variables = cms.PSet(
-        et  = Var("tauEt",  float, precision=l1_float_precision_),
+        pt  = Var("tauEt",  float, precision=l1_float_precision_), # Define as pt in nano, as required by menu tools downstream
         phi = Var("phi", float, precision=l1_float_precision_),
         eta = Var("eta", float, precision=l1_float_precision_),
     )

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -222,6 +222,18 @@ puppiMetTable = cms.EDProducer(
     )
 )
 
+puppiMLMetTable = cms.EDProducer(
+    "SimpleCandidateFlatTableProducer",
+    src = cms.InputTag("l1tMETMLProducer",""),
+    name = cms.string("L1puppiMLMET"),
+    doc = cms.string("Puppi ML MET, origin: Correlator"),
+    singleton = cms.bool(True), # the number of entries is variable
+    variables = cms.PSet(
+        l1PtVars,
+        et = Var("et",float)
+    )
+)
+
 sc4SumsTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
     src = cms.InputTag("l1tSC4PFL1PuppiCorrectedEmulatorMHT",""),
@@ -329,6 +341,7 @@ p2L1TablesTask = cms.Task(
     caloJetTable,
     # ## sums
     puppiMetTable,
+    puppiMLMetTable,
     sc4SumsTable,
     histoSumsTable,
     # taus


### PR DESCRIPTION
Update the calo jet and tau objects to the emulated objects added in the recent PR.  Add the HPS tau and NNCaloTau objects to the nano for the first time.

The NN Calo Tau and HPS Tau PRs are not yet merged, so I merged them in my local area to integrate them into the nano.  There will also need to be another PR to the IB to add some of the objects to the L1 sequence and event content.

Relevant PRs to the IB:

- NN Calo Tau [#1197](https://github.com/cms-l1t-offline/cmssw/pull/1197)
- HPS Tau [#1175](https://github.com/cms-l1t-offline/cmssw/pull/1175)
- Calo Jets/Taus [#1174](https://github.com/cms-l1t-offline/cmssw/pull/1174) and [1189](https://github.com/cms-l1t-offline/cmssw/pull/1189)

----

New, also add the new ML MET to the nano, relevant PR : [#1193](https://github.com/cms-l1t-offline/cmssw/pull/1193)

@artlbv 