### PR TITLE
Update for V34 IB 1400pre3v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,16 @@ NanoAOD ntupler for Phase-2 L1 Objects
 
 ## Setup
 
-This is for version `V33` that is based on the IB tag `phase2-l1t-1400pre3_v2` with these instructions:
-https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TPhase2Instructions#Recipe_for_phase2_l1t_1400pre3_v2
+This is for version `V34` that is based on the IB tag `phase2-l1t-1400pre3_v5` with these instructions:
+https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TPhase2Instructions#Recipe_for_phase2_l1t_1400pre3_v5
 
 ```bash
 cmsrel CMSSW_14_0_0_pre3
 cd CMSSW_14_0_0_pre3/src/
 cmsenv
 git cms-init
-git cms-checkout-topic -u cms-l1t-offline:phase2-l1t-1400pre3_v2
+git cms-checkout-topic -u cms-l1t-offline:phase2-l1t-1400pre3_v5
 scram b -j 8
-
-#Get missing data files for NN Calo Taus
-cd ../../
-git clone https://github.com/jonamotta/L1Trigger-L1CaloTrigger.git
-cd CMSSW_14_0_0_pre3/src/
-git cms-addpkg L1Trigger/L1CaloTrigger
-mkdir L1Trigger/L1CaloTrigger/data
-cp -r ../../L1Trigger-L1CaloTrigger/Phase2_NNCaloTaus L1Trigger/L1CaloTrigger/data
 
 ### ADDING NANO
 git clone git@github.com:cms-l1-dpg/Phase2-L1Nano.git PhysicsTools/L1Nano
@@ -33,7 +25,7 @@ scram b -j 8
 
 In the `test` directory there is a `cmsRun` config to rerun the L1 + Track trigger + the P2GT emulator and produce the nano ntuple from these outputs.
 
-Usage: `cmsRun test/v33_rerunL1wTT_cfg.py`
+Usage: `cmsRun test/v34_rerunL1wTT_cfg.py`
 
 ### Via cmsDriver
 
@@ -43,9 +35,9 @@ One can append the L1Nano output to the `cmsDriver` command via this customisati
 -s USER:PhysicsTools/L1Nano/l1tPh2Nano_cff.l1tPh2NanoTask --customise PhysicsTools/L1Nano/l1tPh2Nano_cff.addFullPh2L1Nano
 ```
 
-`cmsDriver` command (w/ Track Trigger, based on [the 1400pre3 recipe from the Offline SW twiki](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TPhase2Instructions#Recipe_for_phase2_l1t_1400pre3_v2):
+`cmsDriver` command (w/ Track Trigger, based on [the 1400pre3 recipe from the Offline SW twiki](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TPhase2Instructions#Recipe_for_phase2_l1t_1400pre3_v5):
 ```bash
-cmsDriver.py step1 --conditions 131X_mcRun4_realistic_v9 -n 2 --era Phase2C17I13M9 --eventcontent FEVTDEBUGHLT -s RAW2DIGI,L1,L1TrackTrigger,L1P2GT --datatier GEN-SIM-DIGI-RAW-MINIAOD --fileout file:test.root --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2.addHcalTriggerPrimitives,L1Trigger/Configuration/customisePhase2FEVTDEBUGHLT.customisePhase2FEVTDEBUGHLT,L1Trigger/Configuration/customisePhase2TTNoMC.customisePhase2TTNoMC --geometry Extended2026D95 --nThreads 8 --filein /store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/005bc30b-cf79-4b3b-9ec1-a80e13072afd.root --mc --inputCommands=keep *, drop l1tPFJets_*_*_* --outputCommands=drop l1tPFJets_*_*_*
+cmsDriver.py step1 step1 --conditions 131X_mcRun4_realistic_v9 -n 2 --era Phase2C17I13M9 --eventcontent NANOAOD -s RAW2DIGI,L1,L1TrackTrigger,L1P2GT,USER:PhysicsTools/L1Nano/l1tPh2Nano_cff.l1tPh2NanoTask --customise PhysicsTools/L1Nano/l1tPh2Nano_cff.addFullPh2L1Nano --datatier GEN-SIM-DIGI-RAW-MINIAOD --fileout file:test.root --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2.addHcalTriggerPrimitives,L1Trigger/Configuration/customisePhase2TTNoMC.customisePhase2TTNoMC --geometry Extended2026D95 --nThreads 8 --filein /store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/005bc30b-cf79-4b3b-9ec1-a80e13072afd.root --mc --inputCommands=keep *, drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt_*_* --outputCommands=drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt_*_*
 ```
 
 

--- a/python/l1tPh2GTtables_cff.py
+++ b/python/l1tPh2GTtables_cff.py
@@ -86,9 +86,17 @@ gtTkMuTable = gtTkEleTable.clone(
     src = cms.InputTag('l1tGTProducer','GMTTkMuons'),
     name = cms.string("L1GTgmtTkMuon"),
     doc = cms.string("GT GMT tkMuon"),
+    variables = cms.PSet(
+        l1GTObjVars,
+        z0 = Var("vz",float),
+        charge = Var("charge", int, doc="charge id"),
+        ## hw
+        hwQual = Var("hwQual_toInt()",int),
+        hwD0 = Var("hwD0_toInt()",int),
+        hwZ0 = Var("hwZ0_toInt()",int),
+        # hwBeta = Var("hwBeta_toInt()",int)
+    )
 )
-gtTkMuTable.variables.hwD0 = Var("hwD0_toInt()",int)
-gtTkMuTable.variables.hwBeta = Var("hwBeta_toInt()",int)
 
 gtSaMuTable = gtTkMuTable.clone(
     src = cms.InputTag('l1tGTProducer','GMTSaPromptMuons'),

--- a/python/l1tPh2GTtables_cff.py
+++ b/python/l1tPh2GTtables_cff.py
@@ -87,6 +87,20 @@ gtTkMuTable = gtTkEleTable.clone(
     name = cms.string("L1GTgmtTkMuon"),
     doc = cms.string("GT GMT tkMuon"),
 )
+gtTkMuTable.variables.hwD0 = Var("hwD0_toInt()",int)
+gtTkMuTable.variables.hwBeta = Var("hwBeta_toInt()",int)
+
+gtSaMuTable = gtTkMuTable.clone(
+    src = cms.InputTag('l1tGTProducer','GMTSaPromptMuons'),
+    name = cms.string("L1GTgmtMuon"),
+    doc = cms.string("GT GMT standalone Muon"),
+)
+
+gtSaDispMuTable = gtTkMuTable.clone(
+    src = cms.InputTag('l1tGTProducer','GMTSaDisplacedMuons'),
+    name = cms.string("L1GTgmtDispMuon"),
+    doc = cms.string("GT GMT standalone displaced Muon"),
+)
 
 ## GT seededCone puppi Jets
 gtSCJetsTable = cms.EDProducer(
@@ -148,6 +162,7 @@ p2GTL1TablesTask = cms.Task(
     gtTkPhoTable,
     gtTkEleTable,
     gtTkMuTable,
+    gtSaMuTable, gtSaDispMuTable,
     gtSCJetsTable,
     gtNNTauTable,
     gtEtSumTable,

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -91,6 +91,12 @@ gttHtSumTable = cms.EDProducer(
     )
 )
 
+gttExtHtSumTable = gttHtSumTable.clone(
+    src = cms.InputTag("l1tTrackerEmuHTMissExtended","L1TrackerEmuHTMissExtended"),
+    name = cms.string("L1ExtTrackHT"),
+    doc = cms.string("GTT Extended Track Missing HT"),
+)
+
 ### Store Primary Vertex only (first vertex)
 pvtxTable = vtxTable.clone(
     maxLen = cms.uint32(1),
@@ -436,5 +442,6 @@ p2L1TablesTask = cms.Task(
     gttExtTrackJetsTable,
     gttEtSumTable,
     gttHtSumTable,
+    gttExtHtSumTable,
 )
 

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -201,7 +201,7 @@ staMuTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
     src = cms.InputTag('l1tSAMuonsGmt','promptSAMuons'),
     name = cms.string("L1gmtMuon"),
-    doc = cms.string("GMT standalone Muons"),
+    doc = cms.string("GMT standalone Muons, origin: GMT"),
     cut = cms.string(""),
     singleton = cms.bool(False), # the number of entries is variable
     variables = cms.PSet(
@@ -211,13 +211,13 @@ staMuTable = cms.EDProducer(
         chargeNoPh = Var("charge", int, doc="charge id"),
 
         ## physical values
-        #phPt = Var("phPt()",float),
+        charge  = Var("phCharge", int, doc="charge id"),
         pt  = Var("phPt()",float),
         eta = Var("phEta()",float),
         phi = Var("phPhi()",float),
         z0 = Var("phZ0()",float),
         d0 = Var("phD0()",float),
-        charge  = Var("phCharge", int, doc="charge id"),
+        beta = Var("phBeta()",float),
 
         ## hw Values
         hwPt = Var("hwPt()",int,doc="hardware pt"),
@@ -232,10 +232,15 @@ staMuTable = cms.EDProducer(
     )
 )
 
+staDisplacedMuTable = staMuTable.clone(
+    src = cms.InputTag("l1tSAMuonsGmt", "displacedSAMuons"),
+    name = cms.string("L1gmtDispMuon"),
+    doc = cms.string("GMT standalone displaced Muons, origin: GMT"),
+)
 gmtTkMuTable = staMuTable.clone(
-    src = cms.InputTag('l1tTkMuonsGmtLowPtFix','l1tTkMuonsGmtLowPtFix'),
+    src = cms.InputTag('l1tTkMuonsGmt'),
     name = cms.string("L1gmtTkMuon"),
-    doc = cms.string("GMT Tk Muons"),
+    doc = cms.string("GMT Tk Muons, origin: GMT"),
 )
 # gmtTkMuTable.variables.nStubs = Var("stubs().size()",int,doc="number of stubs")
 
@@ -401,7 +406,7 @@ hpsTauTable = cms.EDProducer(
 p2L1TablesTask = cms.Task(
     ## Muons
     gmtTkMuTable,
-    staMuTable,
+    staMuTable, staDisplacedMuTable,
     ## EG
     tkEleTable,
     tkPhotonTable,

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -217,7 +217,7 @@ staMuTable = cms.EDProducer(
         phi = Var("phPhi()",float),
         z0 = Var("phZ0()",float),
         d0 = Var("phD0()",float),
-        beta = Var("phBeta()",float),
+        # beta = Var("phBeta()",float), # does not exist
 
         ## hw Values
         hwPt = Var("hwPt()",int,doc="hardware pt"),

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -271,6 +271,7 @@ sc4ExtJetTable = sc4JetTable.clone(
     doc = cms.string("SeededCone 0.4 Puppi jet from extended Puppi,  origin: Correlator"),
     externalVariables = cms.PSet(
         btagScore = ExtVar(cms.InputTag("l1tBJetProducerPuppiCorrectedEmulator", "L1PFBJets"),float, doc="NNBtag score"),
+        llpTagScore = ExtVar(cms.InputTag("l1tTOoLLiPProducerCorrectedEmulator", "L1PFLLPJets"),float, doc="NN LLP Tag score"),
     ),
 )
 

--- a/test/v34_rerunL1wTT_cfg.py
+++ b/test/v34_rerunL1wTT_cfg.py
@@ -1,0 +1,185 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: step1 --conditions 131X_mcRun4_realistic_v9 -n 2 --era Phase2C17I13M9 --eventcontent NANOAOD -s RAW2DIGI,L1,L1TrackTrigger,L1P2GT,USER:PhysicsTools/L1Nano/l1tPh2Nano_cff.l1tPh2NanoTask --customise PhysicsTools/L1Nano/l1tPh2Nano_cff.addFullPh2L1Nano --datatier GEN-SIM-DIGI-RAW-MINIAOD --fileout file:test.root --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2.addHcalTriggerPrimitives,L1Trigger/Configuration/customisePhase2TTNoMC.customisePhase2TTNoMC --geometry Extended2026D95 --nThreads 8 --filein /store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/005bc30b-cf79-4b3b-9ec1-a80e13072afd.root --mc --inputCommands=keep *, drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt_*_* --outputCommands=drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt_*_*
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
+
+process = cms.Process('USER',Phase2C17I13M9)
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.Geometry.GeometryExtended2026D95Reco_cff')
+process.load('Configuration.StandardSequences.MagneticField_cff')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.L1TrackTrigger_cff')
+process.load('Configuration.StandardSequences.SimPhase2L1GlobalTriggerEmulator_cff')
+process.load('L1Trigger.Configuration.Phase2GTMenus.SeedDefinitions.prototypeSeeds')
+process.load('PhysicsTools.L1Nano.l1tPh2Nano_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(2),
+    output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    dropDescendantsOfDroppedBranches = cms.untracked.bool(False),
+    fileNames = cms.untracked.vstring(
+        # '/store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/005bc30b-cf79-4b3b-9ec1-a80e13072afd.root'
+        "/store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/005bc30b-cf79-4b3b-9ec1-a80e13072afd.root"
+        ),
+    inputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop l1tPFJets_*_*_*',
+        'drop l1tTrackerMuons_l1tTkMuonsGmt_*_*'
+    ),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+    IgnoreCompletely = cms.untracked.vstring(),
+    Rethrow = cms.untracked.vstring(),
+    TryToContinue = cms.untracked.vstring(),
+    accelerators = cms.untracked.vstring('*'),
+    allowUnscheduled = cms.obsolete.untracked.bool,
+    canDeleteEarly = cms.untracked.vstring(),
+    deleteNonConsumedUnscheduledModules = cms.untracked.bool(True),
+    dumpOptions = cms.untracked.bool(False),
+    emptyRunLumiMode = cms.obsolete.untracked.string,
+    eventSetup = cms.untracked.PSet(
+        forceNumberOfConcurrentIOVs = cms.untracked.PSet(
+            allowAnyLabel_=cms.required.untracked.uint32
+        ),
+        numberOfConcurrentIOVs = cms.untracked.uint32(0)
+    ),
+    fileMode = cms.untracked.string('FULLMERGE'),
+    forceEventSetupCacheClearOnNewRun = cms.untracked.bool(False),
+    holdsReferencesToDeleteEarly = cms.untracked.VPSet(),
+    makeTriggerResults = cms.obsolete.untracked.bool,
+    modulesToCallForTryToContinue = cms.untracked.vstring(),
+    modulesToIgnoreForDeleteEarly = cms.untracked.vstring(),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(0),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0),
+    numberOfThreads = cms.untracked.uint32(1),
+    printDependencies = cms.untracked.bool(False),
+    sizeOfStackForThreadsInKB = cms.optional.untracked.uint32,
+    throwIfIllegalParameter = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False)
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('step1 nevts:2'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+process.NANOAODoutput = cms.OutputModule("NanoAODOutputModule",
+    compressionAlgorithm = cms.untracked.string('LZMA'),
+    compressionLevel = cms.untracked.int32(9),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW-MINIAOD'),
+        filterName = cms.untracked.string('')
+    ),
+    fileName = cms.untracked.string('file:test.root'),
+    outputCommands = process.NANOAODEventContent.outputCommands
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '131X_mcRun4_realistic_v9', '')
+process.NANOAODoutput.outputCommands.append('drop l1tPFJets_*_*_*')
+process.NANOAODoutput.outputCommands.append('drop l1tTrackerMuons_l1tTkMuonsGmt_*_*')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1simulation_step = cms.Path(process.SimL1Emulator)
+process.L1TrackTrigger_step = cms.Path(process.L1TrackTrigger)
+process.Phase2L1GTProducer = cms.Path(process.l1tGTProducerSequence)
+process.Phase2L1GTAlgoBlockProducer = cms.Path(process.l1tGTAlgoBlockProducerSequence)
+process.pDoubleEGEle37_24 = cms.Path(process.DoubleEGEle3724)
+process.pDoubleIsoTkPho22_12 = cms.Path(process.DoubleIsoTkPho2212)
+process.pDoublePuppiTau52_52 = cms.Path(process.DoublePuppiTau5252)
+process.pDoubleTkEle25_12 = cms.Path(process.DoubleTkEle2512)
+process.pDoubleTkMuon15_7 = cms.Path(process.DoubleTkMuon157)
+process.pIsoTkEleEGEle22_12 = cms.Path(process.IsoTkEleEGEle2212)
+process.pPuppiHT400 = cms.Path(process.PuppiHT400)
+process.pPuppiHT450 = cms.Path(process.PuppiHT450)
+process.pPuppiMET200 = cms.Path(process.PuppiMET200)
+process.pQuadJet70_55_40_40 = cms.Path(process.QuadJet70554040)
+process.pSingleEGEle51 = cms.Path(process.SingleEGEle51)
+process.pSingleIsoTkEle28 = cms.Path(process.SingleIsoTkEle28)
+process.pSingleIsoTkPho36 = cms.Path(process.SingleIsoTkPho36)
+process.pSinglePuppiJet230 = cms.Path(process.SinglePuppiJet230)
+process.pSingleTkEle36 = cms.Path(process.SingleTkEle36)
+process.pSingleTkMuon22 = cms.Path(process.SingleTkMuon22)
+process.pTripleTkMuon5_3_3 = cms.Path(process.TripleTkMuon533)
+process.user_step = cms.Path(process.l1tPh2NanoTask)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.NANOAODoutput_step = cms.EndPath(process.NANOAODoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1simulation_step,process.L1TrackTrigger_step,process.Phase2L1GTProducer,process.Phase2L1GTAlgoBlockProducer,process.pDoubleEGEle37_24,process.pDoubleIsoTkPho22_12,process.pDoublePuppiTau52_52,process.pDoubleTkEle25_12,process.pDoubleTkMuon15_7,process.pIsoTkEleEGEle22_12,process.pPuppiHT400,process.pPuppiHT450,process.pPuppiMET200,process.pQuadJet70_55_40_40,process.pSingleEGEle51,process.pSingleIsoTkEle28,process.pSingleIsoTkPho36,process.pSinglePuppiJet230,process.pSingleTkEle36,process.pSingleTkMuon22,process.pTripleTkMuon5_3_3,process.user_step,process.endjob_step,process.NANOAODoutput_step)
+from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
+associatePatAlgosToolsTask(process)
+
+#Setup FWK for multithreaded
+process.options.numberOfThreads = 8
+process.options.numberOfStreams = 0
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from PhysicsTools.L1Nano.l1tPh2Nano_cff
+from PhysicsTools.L1Nano.l1tPh2Nano_cff import addFullPh2L1Nano 
+
+#call to customisation function addFullPh2L1Nano imported from PhysicsTools.L1Nano.l1tPh2Nano_cff
+process = addFullPh2L1Nano(process)
+
+# Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.aging
+from SLHCUpgradeSimulations.Configuration.aging import customise_aging_1000 
+
+#call to customisation function customise_aging_1000 imported from SLHCUpgradeSimulations.Configuration.aging
+process = customise_aging_1000(process)
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.Utils
+from Configuration.DataProcessing.Utils import addMonitoring 
+
+#call to customisation function addMonitoring imported from Configuration.DataProcessing.Utils
+process = addMonitoring(process)
+
+# Automatic addition of the customisation function from L1Trigger.Configuration.customisePhase2
+from L1Trigger.Configuration.customisePhase2 import addHcalTriggerPrimitives 
+
+#call to customisation function addHcalTriggerPrimitives imported from L1Trigger.Configuration.customisePhase2
+process = addHcalTriggerPrimitives(process)
+
+# Automatic addition of the customisation function from L1Trigger.Configuration.customisePhase2TTNoMC
+from L1Trigger.Configuration.customisePhase2TTNoMC import customisePhase2TTNoMC 
+
+#call to customisation function customisePhase2TTNoMC imported from L1Trigger.Configuration.customisePhase2TTNoMC
+process = customisePhase2TTNoMC(process)
+
+# End of customisation functions
+
+
+# Customisation from command line
+
+# Add early deletion of temporary data products to reduce peak memory need
+from Configuration.StandardSequences.earlyDeleteSettings_cff import customiseEarlyDelete
+process = customiseEarlyDelete(process)
+# End adding early deletion

--- a/test/v34_rerunL1wTT_cfg.py
+++ b/test/v34_rerunL1wTT_cfg.py
@@ -145,7 +145,7 @@ from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)
 
 #Setup FWK for multithreaded
-process.options.numberOfThreads = 8
+process.options.numberOfThreads = 1
 process.options.numberOfStreams = 0
 
 # customisation of the process.

--- a/test/v34_rerunL1wTT_cfg.py
+++ b/test/v34_rerunL1wTT_cfg.py
@@ -36,7 +36,13 @@ process.source = cms.Source("PoolSource",
     dropDescendantsOfDroppedBranches = cms.untracked.bool(False),
     fileNames = cms.untracked.vstring(
         # '/store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/005bc30b-cf79-4b3b-9ec1-a80e13072afd.root'
-        "/store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/005bc30b-cf79-4b3b-9ec1-a80e13072afd.root"
+        # "/store/mc/Phase2Spring23DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_L1TFix_Trk1GeV_131X_mcRun4_realistic_v9-v1/50000/005bc30b-cf79-4b3b-9ec1-a80e13072afd.root"
+        "/store/mc/Phase2Spring23DIGIRECOMiniAOD/DYToLL_M-50_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_131X_mcRun4_realistic_v5-v1/30000/0074b621-ce6a-4f66-8536-729c401b09a4.root",
+        "/store/mc/Phase2Spring23DIGIRECOMiniAOD/DYToLL_M-50_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_131X_mcRun4_realistic_v5-v1/30001/b4bddcdb-25e1-4193-b125-a8e1c8f64384.root",
+        "/store/mc/Phase2Spring23DIGIRECOMiniAOD/DYToLL_M-50_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_131X_mcRun4_realistic_v5-v1/30000/e77e895d-2cd7-41a9-a035-cc1457c0a1a3.root",
+        "/store/mc/Phase2Spring23DIGIRECOMiniAOD/DYToLL_M-50_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_131X_mcRun4_realistic_v5-v1/30000/e089e52e-9461-4339-809c-329acef008d6.root",
+        "/store/mc/Phase2Spring23DIGIRECOMiniAOD/DYToLL_M-50_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_131X_mcRun4_realistic_v5-v1/30001/061b4e8c-acd1-4a52-9026-3a6757ad6e9d.root",
+        "/store/mc/Phase2Spring23DIGIRECOMiniAOD/DYToLL_M-50_TuneCP5_14TeV-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_Trk1GeV_131X_mcRun4_realistic_v5-v1/30001/5bad5ebd-c5f3-43dd-aedf-54c4a3b92ed3.root",
         ),
     inputCommands = cms.untracked.vstring(
         'keep *',
@@ -94,7 +100,7 @@ process.NANOAODoutput = cms.OutputModule("NanoAODOutputModule",
         dataTier = cms.untracked.string('GEN-SIM-DIGI-RAW-MINIAOD'),
         filterName = cms.untracked.string('')
     ),
-    fileName = cms.untracked.string('file:test.root'),
+    fileName = cms.untracked.string('file:l1nano.root'),
     outputCommands = process.NANOAODEventContent.outputCommands
 )
 


### PR DESCRIPTION
* Updating the SW recipe for IBv5
* Includes updates for Muons
* Added LLP tagger score for sc4 jets

Content overview: https://alobanov.web.cern.ch/L1T/Phase2/L1Nano/l1menu_nano_V34_1400pre3V5_doc_report.html 