### PR TITLE
Updating with gttTripletTable

### DIFF
--- a/plugins/L1TableProducer.cc
+++ b/plugins/L1TableProducer.cc
@@ -9,7 +9,11 @@ typedef SimpleFlatTableProducer<l1t::P2GTAlgoBlock> P2GTAlgoBlockFlatTableProduc
 #include "DataFormats/L1Trigger/interface/TkJetWord.h"
 typedef SimpleFlatTableProducer<l1t::TkJetWord> SimpleL1TkJetWordCandidateFlatTableProducer;
 
+#include "DataFormats/L1Trigger/interface/TkTripletWord.h"
+typedef SimpleFlatTableProducer<l1t::TkTripletWord> SimpleTkTripletWordCandidateFlatTableProducer;
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleL1VtxWordCandidateFlatTableProducer);
 DEFINE_FWK_MODULE(P2GTAlgoBlockFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleL1TkJetWordCandidateFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTkTripletWordCandidateFlatTableProducer);

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -55,6 +55,36 @@ gttExtTrackJetsTable = gttTrackJetsTable.clone(
     doc = cms.string("GTT Extended Track Jets"),
 )
 
+gttTripletTable = cms.EDProducer(
+    "SimpleTkTripletWordCandidateFlatTableProducer",
+    src = cms.InputTag("l1tTrackTripletEmulation","L1TrackTripletWord"),
+    name = cms.string("L1TrackTripletWord"),
+    doc = cms.string("GTT Triplets"),
+    singleton = cms.bool(False), # the number of entries is variable
+    variables = cms.PSet(
+        valid = Var("valid()", float, doc="valid"),
+        pt = Var("pt()", float, doc="pt"),
+        eta = Var("glbeta()", float, doc="eta"),
+        phi = Var("glbphi()", float, doc="phi"),
+        mass = Var("mass()", float, doc="mass"),
+        charge = Var("charge()", float, doc="charge"),
+        ditrackMinMass = Var("ditrackMinMass()", float, doc="ditrackMinMass"),
+        ditrackMaxMass = Var("ditrackMaxMass()", float, doc="ditrackMaxMass"),
+        ditrackMinZ0 = Var("ditrackMinZ0()", float, doc="ditrackMinZ0"),
+        ditrackMaxZ0 = Var("ditrackMaxZ0()", float, doc="ditrackMaxZ0"),
+        hwValid = Var("validBits()", "uint", doc="hardware valid"),
+        hwPt = Var("ptBits()", "uint", doc="hardware pt"),
+        hwEta = Var("glbEtaBits()", "uint", doc="hardware eta"),
+        hwPhi = Var("glbPhiBits()", "uint", doc="hardware eta"),
+        hwMass = Var("massBits()", "uint", doc="hardware mass"),
+        hwCharge = Var("chargeBits()", "uint", doc="hardware charge"),
+        hwDitrackMinMass = Var("ditrackMinMassBits()", "uint", doc="hardware DitrackMinMass"),
+        hwDitrackMaxMass = Var("ditrackMaxMassBits()", "uint", doc="hardware DitrackMaxMass"),
+        hwDitrackMinZ0 = Var("ditrackMinZ0Bits()", "uint", doc="hardware DitrackMinZ0"),
+        hwDitrackMaxZ0 = Var("ditrackMaxZ0Bits()", "uint", doc="hardware DitrackMaxZ0")
+    )
+)
+
 gttEtSumTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
     src = cms.InputTag("l1tTrackerEmuEtMiss", "L1TrackerEmuEtMiss"),
@@ -440,6 +470,7 @@ p2L1TablesTask = cms.Task(
     pvtxTable,
     gttTrackJetsTable,
     gttExtTrackJetsTable,
+    gttTripletTable,
     gttEtSumTable,
     gttHtSumTable,
     gttExtHtSumTable,


### PR DESCRIPTION
Here I am adding the GTT Triplets into L1Nano.
Please note that we actually need to run the Triplet emulator and therefore need to add the following code:
```
#Track Triplet Emulator
from L1Trigger.L1TTrackMatch.l1tTrackTripletEmulation_cfi import *
_phase2_siml1emulator.add(l1tTrackTripletEmulation)
```
Into:
https://github.com/cms-l1t-offline/cmssw/blob/phase2-l1t-integration-14_0_0_pre3/L1Trigger/Configuration/python/SimL1Emulator_cff.py#L224