### PR TITLE
Update table producers to more specialised classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,15 @@ NanoAOD ntupler for Phase-2 L1 Objects
 
 ## Setup
 
-This is for version `V38` that is based on the IB tag `phase2-l1t-1400pre3_v9` with these instructions:
-https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TPhase2Instructions#Recipe_for_phase2_l1t_1400pre3_v9
+This is for version `V43` that is based on CMSSW_14_1_0_pre7.
+For more information on the latest L1T Phase 2 software developments in CMSSW see: https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideL1TPhase2Instructions#Development
 
-Corresponding menu twiki section: https://twiki.cern.ch/twiki/bin/view/CMS/PhaseIIL1TriggerMenuTools#Phase_2_L1_Trigger_objects_for_2
+Corresponding menu twiki section: https://twiki.cern.ch/twiki/bin/viewauth/CMS/PhaseIIL1TriggerMenuTools#Phase_2_L1_Trigger_objects_based
 
 ```bash
-cmsrel CMSSW_14_0_0_pre3
-cd CMSSW_14_0_0_pre3/src/
+cmsrel CMSSW_14_1_0_pre7
+cd CMSSW_14_1_0_pre7/src/
 cmsenv
-git cms-init
-git cms-checkout-topic -u cms-l1t-offline:phase2-l1t-1400pre3_v9
 
 ### ADDING NANO
 git clone git@github.com:cms-l1-dpg/Phase2-L1Nano.git PhysicsTools/L1Nano
@@ -26,7 +24,7 @@ scram b -j 8
 
 In the `test` directory there is a `cmsRun` config to rerun the L1 + **(L1 Track trigger)** + the P2GT emulator and produce the nano ntuple from these outputs.
 
-Usage: `cmsRun test/V38_rerunL1wTT_cfg.py`
+Usage: `cmsRun test/V43_rerunL1wTT_cfg.py`
 
 ### Via cmsDriver
 

--- a/plugins/BuildFile.xml
+++ b/plugins/BuildFile.xml
@@ -4,6 +4,9 @@
 <use name="DataFormats/Candidate"/>
 <use name="DataFormats/L1TGlobal"/>
 <use name="DataFormats/L1Trigger"/>
+<use name="DataFormats/L1TCorrelator"/>
+<use name="DataFormats/L1TMuonPhase2"/>
+<use name="DataFormats/L1TParticleFlow"/>
 <use name="DataFormats/NanoAOD"/>
 <use name="DataFormats/PatCandidates"/>
 <use name="DataFormats/ProtonReco"/>

--- a/plugins/L1TableProducer.cc
+++ b/plugins/L1TableProducer.cc
@@ -34,25 +34,25 @@ typedef SimpleFlatTableProducer<l1t::TkTripletWord> SimpleTkTripletWordCandidate
 typedef SimpleFlatTableProducer<l1t::L1Candidate> SimpleTriggerL1CandidateFlatTableProducer;
 
 // #include "DataFormats/L1TCorrelator/interface/TkEm.h"
-// typedef BXVectorSimpleFlatTableProducer<l1t::TkEm> SimpleTriggerL1TkEmFlatTableProducer;
+// typedef SimpleFlatTableProducer<l1t::TkEm> SimpleTriggerL1TkEmFlatTableProducer;
 
 #include "DataFormats/L1TCorrelator/interface/TkElectron.h"
-typedef BXVectorSimpleFlatTableProducer<l1t::TkElectron> SimpleTriggerL1TkElectronFlatTableProducer;
+typedef SimpleFlatTableProducer<l1t::TkElectron> SimpleTriggerL1TkElectronFlatTableProducer;
 
 #include "DataFormats/L1TMuonPhase2/interface/SAMuon.h"
-typedef BXVectorSimpleFlatTableProducer<l1t::SAMuon> SimpleTriggerL1SAMuonFlatTableProducer;
+typedef SimpleFlatTableProducer<l1t::SAMuon> SimpleTriggerL1SAMuonFlatTableProducer;
 
 #include "DataFormats/L1TCalorimeterPhase2/interface/Phase2L1CaloJet.h"
-typedef BXVectorSimpleFlatTableProducer<l1tp2::Phase2L1CaloJet> SimpleTriggerL1CaloJetFlatTableProducer;
+typedef SimpleFlatTableProducer<l1tp2::Phase2L1CaloJet> SimpleTriggerL1CaloJetFlatTableProducer;
 
 // #include "DataFormats/L1TParticleFlow/interface/PFJet.h"
-// typedef BXVectorSimpleFlatTableProducer<l1t::PFJet> SimpleTriggerL1PFJetFlatTableProducer;
+// typedef SimpleFlatTableProducer<l1t::PFJet> SimpleTriggerL1PFJetFlatTableProducer;
 
 #include "DataFormats/L1TParticleFlow/interface/PFTau.h"
-typedef BXVectorSimpleFlatTableProducer<l1t::PFTau> SimpleTriggerL1PFTauFlatTableProducer;
+typedef SimpleFlatTableProducer<l1t::PFTau> SimpleTriggerL1PFTauFlatTableProducer;
 
 // #include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
-// typedef BXVectorSimpleFlatTableProducer<l1t::HPSPFTau> SimpleTriggerL1HPSPFTauFlatTableProducer;
+// typedef SimpleFlatTableProducer<l1t::HPSPFTau> SimpleTriggerL1HPSPFTauFlatTableProducer;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleL1VtxWordCandidateFlatTableProducer);

--- a/plugins/L1TableProducer.cc
+++ b/plugins/L1TableProducer.cc
@@ -33,8 +33,8 @@ typedef SimpleFlatTableProducer<l1t::TkTripletWord> SimpleTkTripletWordCandidate
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 typedef SimpleFlatTableProducer<l1t::L1Candidate> SimpleTriggerL1CandidateFlatTableProducer;
 
-// #include "DataFormats/L1TCorrelator/interface/TkEm.h"
-// typedef SimpleFlatTableProducer<l1t::TkEm> SimpleTriggerL1TkEmFlatTableProducer;
+#include "DataFormats/L1TCorrelator/interface/TkEm.h"
+typedef SimpleFlatTableProducer<l1t::TkEm> SimpleTriggerL1TkEmFlatTableProducer;
 
 #include "DataFormats/L1TCorrelator/interface/TkElectron.h"
 typedef SimpleFlatTableProducer<l1t::TkElectron> SimpleTriggerL1TkElectronFlatTableProducer;
@@ -67,7 +67,7 @@ DEFINE_FWK_MODULE(SimpleTkTripletWordCandidateFlatTableProducer);
 // DEFINE_FWK_MODULE(SimpleTriggerL1TauFlatTableProducer);
 // DEFINE_FWK_MODULE(SimpleTriggerL1EtSumFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1CandidateFlatTableProducer);
-// DEFINE_FWK_MODULE(SimpleTriggerL1TkEmFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1TkEmFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1TkElectronFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1SAMuonFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1CaloJetFlatTableProducer);

--- a/plugins/L1TableProducer.cc
+++ b/plugins/L1TableProducer.cc
@@ -15,21 +15,6 @@ typedef SimpleFlatTableProducer<l1t::TkJetWord> SimpleL1TkJetWordCandidateFlatTa
 #include "DataFormats/L1Trigger/interface/TkTripletWord.h"
 typedef SimpleFlatTableProducer<l1t::TkTripletWord> SimpleTkTripletWordCandidateFlatTableProducer;
 
-// #include "DataFormats/L1Trigger/interface/EGamma.h"
-// typedef BXVectorSimpleFlatTableProducer<l1t::EGamma> SimpleTriggerL1EGFlatTableProducer;
-
-// #include "DataFormats/L1Trigger/interface/Jet.h"
-// typedef BXVectorSimpleFlatTableProducer<l1t::Jet> SimpleTriggerL1JetFlatTableProducer;
-
-// #include "DataFormats/L1Trigger/interface/Tau.h"
-// typedef BXVectorSimpleFlatTableProducer<l1t::Tau> SimpleTriggerL1TauFlatTableProducer;
-
-// #include "DataFormats/L1Trigger/interface/Muon.h"
-// typedef BXVectorSimpleFlatTableProducer<l1t::Muon> SimpleTriggerL1MuonFlatTableProducer;
-
-// #include "DataFormats/L1Trigger/interface/EtSum.h"
-// typedef BXVectorSimpleFlatTableProducer<l1t::EtSum> SimpleTriggerL1EtSumFlatTableProducer;
-
 #include "DataFormats/L1Trigger/interface/L1Candidate.h"
 typedef SimpleFlatTableProducer<l1t::L1Candidate> SimpleTriggerL1CandidateFlatTableProducer;
 
@@ -48,9 +33,6 @@ typedef SimpleFlatTableProducer<l1t::TrackerMuon> SimpleTriggerL1TrackerMuonFlat
 #include "DataFormats/L1TCalorimeterPhase2/interface/Phase2L1CaloJet.h"
 typedef SimpleFlatTableProducer<l1tp2::Phase2L1CaloJet> SimpleTriggerL1CaloJetFlatTableProducer;
 
-// #include "DataFormats/L1TParticleFlow/interface/PFJet.h"
-// typedef SimpleFlatTableProducer<l1t::PFJet> SimpleTriggerL1PFJetFlatTableProducer;
-
 #include "DataFormats/L1TParticleFlow/interface/PFTau.h"
 typedef SimpleFlatTableProducer<l1t::PFTau> SimpleTriggerL1PFTauFlatTableProducer;
 
@@ -63,18 +45,11 @@ DEFINE_FWK_MODULE(P2GTAlgoBlockFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleP2GTCandidateFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleL1TkJetWordCandidateFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTkTripletWordCandidateFlatTableProducer);
-
-// DEFINE_FWK_MODULE(SimpleTriggerL1EGFlatTableProducer);
-// DEFINE_FWK_MODULE(SimpleTriggerL1JetFlatTableProducer);
-// DEFINE_FWK_MODULE(SimpleTriggerL1MuonFlatTableProducer);
-// DEFINE_FWK_MODULE(SimpleTriggerL1TauFlatTableProducer);
-// DEFINE_FWK_MODULE(SimpleTriggerL1EtSumFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1CandidateFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1TkEmFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1TkElectronFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1SAMuonFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1TrackerMuonFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1CaloJetFlatTableProducer);
-// DEFINE_FWK_MODULE(SimpleTriggerL1PFJetFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1PFTauFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1HPSPFTauFlatTableProducer);

--- a/plugins/L1TableProducer.cc
+++ b/plugins/L1TableProducer.cc
@@ -42,6 +42,9 @@ typedef SimpleFlatTableProducer<l1t::TkElectron> SimpleTriggerL1TkElectronFlatTa
 #include "DataFormats/L1TMuonPhase2/interface/SAMuon.h"
 typedef SimpleFlatTableProducer<l1t::SAMuon> SimpleTriggerL1SAMuonFlatTableProducer;
 
+#include "DataFormats/L1TMuonPhase2/interface/TrackerMuon.h"
+typedef SimpleFlatTableProducer<l1t::TrackerMuon> SimpleTriggerL1TrackerMuonFlatTableProducer;
+
 #include "DataFormats/L1TCalorimeterPhase2/interface/Phase2L1CaloJet.h"
 typedef SimpleFlatTableProducer<l1tp2::Phase2L1CaloJet> SimpleTriggerL1CaloJetFlatTableProducer;
 
@@ -70,6 +73,7 @@ DEFINE_FWK_MODULE(SimpleTriggerL1CandidateFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1TkEmFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1TkElectronFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1SAMuonFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1TrackerMuonFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1CaloJetFlatTableProducer);
 // DEFINE_FWK_MODULE(SimpleTriggerL1PFJetFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1PFTauFlatTableProducer);

--- a/plugins/L1TableProducer.cc
+++ b/plugins/L1TableProducer.cc
@@ -54,8 +54,8 @@ typedef SimpleFlatTableProducer<l1tp2::Phase2L1CaloJet> SimpleTriggerL1CaloJetFl
 #include "DataFormats/L1TParticleFlow/interface/PFTau.h"
 typedef SimpleFlatTableProducer<l1t::PFTau> SimpleTriggerL1PFTauFlatTableProducer;
 
-// #include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
-// typedef SimpleFlatTableProducer<l1t::HPSPFTau> SimpleTriggerL1HPSPFTauFlatTableProducer;
+#include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
+typedef SimpleFlatTableProducer<l1t::HPSPFTau> SimpleTriggerL1HPSPFTauFlatTableProducer;
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleL1VtxWordCandidateFlatTableProducer);
@@ -77,4 +77,4 @@ DEFINE_FWK_MODULE(SimpleTriggerL1TrackerMuonFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1CaloJetFlatTableProducer);
 // DEFINE_FWK_MODULE(SimpleTriggerL1PFJetFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTriggerL1PFTauFlatTableProducer);
-// DEFINE_FWK_MODULE(SimpleTriggerL1HPSPFTauFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1HPSPFTauFlatTableProducer);

--- a/plugins/L1TableProducer.cc
+++ b/plugins/L1TableProducer.cc
@@ -6,14 +6,71 @@ typedef SimpleFlatTableProducer<l1t::VertexWord> SimpleL1VtxWordCandidateFlatTab
 #include "DataFormats/L1Trigger/interface/P2GTAlgoBlock.h"
 typedef SimpleFlatTableProducer<l1t::P2GTAlgoBlock> P2GTAlgoBlockFlatTableProducer;
 
+#include "DataFormats/L1Trigger/interface/P2GTCandidate.h"
+typedef SimpleFlatTableProducer<l1t::P2GTCandidate> SimpleP2GTCandidateFlatTableProducer;
+
 #include "DataFormats/L1Trigger/interface/TkJetWord.h"
 typedef SimpleFlatTableProducer<l1t::TkJetWord> SimpleL1TkJetWordCandidateFlatTableProducer;
 
 #include "DataFormats/L1Trigger/interface/TkTripletWord.h"
 typedef SimpleFlatTableProducer<l1t::TkTripletWord> SimpleTkTripletWordCandidateFlatTableProducer;
 
+// #include "DataFormats/L1Trigger/interface/EGamma.h"
+// typedef BXVectorSimpleFlatTableProducer<l1t::EGamma> SimpleTriggerL1EGFlatTableProducer;
+
+// #include "DataFormats/L1Trigger/interface/Jet.h"
+// typedef BXVectorSimpleFlatTableProducer<l1t::Jet> SimpleTriggerL1JetFlatTableProducer;
+
+// #include "DataFormats/L1Trigger/interface/Tau.h"
+// typedef BXVectorSimpleFlatTableProducer<l1t::Tau> SimpleTriggerL1TauFlatTableProducer;
+
+// #include "DataFormats/L1Trigger/interface/Muon.h"
+// typedef BXVectorSimpleFlatTableProducer<l1t::Muon> SimpleTriggerL1MuonFlatTableProducer;
+
+// #include "DataFormats/L1Trigger/interface/EtSum.h"
+// typedef BXVectorSimpleFlatTableProducer<l1t::EtSum> SimpleTriggerL1EtSumFlatTableProducer;
+
+#include "DataFormats/L1Trigger/interface/L1Candidate.h"
+typedef SimpleFlatTableProducer<l1t::L1Candidate> SimpleTriggerL1CandidateFlatTableProducer;
+
+// #include "DataFormats/L1TCorrelator/interface/TkEm.h"
+// typedef BXVectorSimpleFlatTableProducer<l1t::TkEm> SimpleTriggerL1TkEmFlatTableProducer;
+
+#include "DataFormats/L1TCorrelator/interface/TkElectron.h"
+typedef BXVectorSimpleFlatTableProducer<l1t::TkElectron> SimpleTriggerL1TkElectronFlatTableProducer;
+
+#include "DataFormats/L1TMuonPhase2/interface/SAMuon.h"
+typedef BXVectorSimpleFlatTableProducer<l1t::SAMuon> SimpleTriggerL1SAMuonFlatTableProducer;
+
+#include "DataFormats/L1TCalorimeterPhase2/interface/Phase2L1CaloJet.h"
+typedef BXVectorSimpleFlatTableProducer<l1tp2::Phase2L1CaloJet> SimpleTriggerL1CaloJetFlatTableProducer;
+
+// #include "DataFormats/L1TParticleFlow/interface/PFJet.h"
+// typedef BXVectorSimpleFlatTableProducer<l1t::PFJet> SimpleTriggerL1PFJetFlatTableProducer;
+
+#include "DataFormats/L1TParticleFlow/interface/PFTau.h"
+typedef BXVectorSimpleFlatTableProducer<l1t::PFTau> SimpleTriggerL1PFTauFlatTableProducer;
+
+// #include "DataFormats/L1TParticleFlow/interface/HPSPFTau.h"
+// typedef BXVectorSimpleFlatTableProducer<l1t::HPSPFTau> SimpleTriggerL1HPSPFTauFlatTableProducer;
+
 #include "FWCore/Framework/interface/MakerMacros.h"
 DEFINE_FWK_MODULE(SimpleL1VtxWordCandidateFlatTableProducer);
 DEFINE_FWK_MODULE(P2GTAlgoBlockFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleP2GTCandidateFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleL1TkJetWordCandidateFlatTableProducer);
 DEFINE_FWK_MODULE(SimpleTkTripletWordCandidateFlatTableProducer);
+
+// DEFINE_FWK_MODULE(SimpleTriggerL1EGFlatTableProducer);
+// DEFINE_FWK_MODULE(SimpleTriggerL1JetFlatTableProducer);
+// DEFINE_FWK_MODULE(SimpleTriggerL1MuonFlatTableProducer);
+// DEFINE_FWK_MODULE(SimpleTriggerL1TauFlatTableProducer);
+// DEFINE_FWK_MODULE(SimpleTriggerL1EtSumFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1CandidateFlatTableProducer);
+// DEFINE_FWK_MODULE(SimpleTriggerL1TkEmFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1TkElectronFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1SAMuonFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1CaloJetFlatTableProducer);
+// DEFINE_FWK_MODULE(SimpleTriggerL1PFJetFlatTableProducer);
+DEFINE_FWK_MODULE(SimpleTriggerL1PFTauFlatTableProducer);
+// DEFINE_FWK_MODULE(SimpleTriggerL1HPSPFTauFlatTableProducer);

--- a/python/l1tPh2GTtables_cff.py
+++ b/python/l1tPh2GTtables_cff.py
@@ -27,7 +27,8 @@ gtAlgoTable = cms.EDProducer(
 
 ### Vertex
 gtVtxTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    "SimpleP2GTCandidateFlatTableProducer",
     src = cms.InputTag('l1tGTProducer','GTTPrimaryVert'),
     cut = cms.string(""),
     name = cms.string("L1GTVertex"),
@@ -51,7 +52,8 @@ gtPvTable = gtVtxTable.clone(
 
 ### GT
 gtTkPhoTable =cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    "SimpleP2GTCandidateFlatTableProducer",
     src = cms.InputTag('l1tGTProducer','CL2Photons'),
     name = cms.string("L1GTtkPhoton"),
     doc = cms.string("GT tkPhotons"),
@@ -61,12 +63,12 @@ gtTkPhoTable =cms.EDProducer(
         l1GTObjVars,
         ## hw values
         # hwPt = Var("hwPT_toInt()",int,doc="hardware pt"),
-        hwQual = Var("hwQual_toInt()",int),
-        hwIso = Var("hwIso_toInt()",int),
+        hwQual = Var("hwQualityScore_toInt()",int),
+        hwIso = Var("hwIsolationPT_toInt()",int),
         ## more physical values
         ## using the GT scales for HW to physicsal vonversion, see scales in https://github.com/cms-sw/cmssw/blob/master/L1Trigger/Phase2L1GT/python/l1tGTScales.py
-        iso = Var(f"hwIso_toInt()*{scale_parameter.isolationPT_lsb.value()}",float, doc = "absolute isolation"),
-        relIso = Var(f"hwIso_toInt()*{scale_parameter.isolationPT_lsb.value()} / pt",float, doc = "relative isolation")
+        iso = Var(f"hwIsolationPT_toInt()*{scale_parameter.isolationPT_lsb.value()}",float, doc = "absolute isolation"),
+        relIso = Var(f"hwIsolationPT_toInt()*{scale_parameter.isolationPT_lsb.value()} / pt",float, doc = "relative isolation")
     )
 )
 
@@ -91,7 +93,7 @@ gtTkMuTable = gtTkEleTable.clone(
         z0 = Var("vz",float),
         charge = Var("charge", int, doc="charge id"),
         ## hw
-        hwQual = Var("hwQual_toInt()",int),
+        hwQual = Var("hwQualityScore_toInt()",int),
         hwD0 = Var("hwD0_toInt()",int),
         hwZ0 = Var("hwZ0_toInt()",int),
         # hwBeta = Var("hwBeta_toInt()",int)
@@ -125,7 +127,8 @@ gtSCJetsTable = cms.EDProducer(
 )
 
 gtNNTauTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    "SimpleP2GTCandidateFlatTableProducer",
     src = cms.InputTag('l1tGTProducer','CL2Taus'),
     cut = cms.string(""),
     name = cms.string("L1GTnnTau"),
@@ -151,7 +154,8 @@ gtEtSumTable = cms.EDProducer(
 )
 
 gtHtSumTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    "SimpleP2GTCandidateFlatTableProducer",
     src = cms.InputTag('l1tGTProducer','CL2HtSum'),
     name = cms.string("L1GTscJetSum"),
     doc = cms.string("GT CL2HtSum"),
@@ -160,7 +164,7 @@ gtHtSumTable = cms.EDProducer(
         # l1GTObjVars,
         mht = Var("pt", float, doc="MHT pt"),
         mhtPhi = Var("phi", float, doc="MHT phi"),
-        ht = Var(f"hwSca_sum_toInt()*{scale_parameter.scalarSumPT_lsb.value()}", float, doc="HT"), ## HACK via hw value!
+        ht = Var(f"hwScalarSumPT_toInt()*{scale_parameter.scalarSumPT_lsb.value()}", float, doc="HT"), ## HACK via hw value!
     )
 )
 

--- a/python/l1tPh2GTtables_cff.py
+++ b/python/l1tPh2GTtables_cff.py
@@ -63,7 +63,7 @@ gtTkPhoTable =cms.EDProducer(
         l1GTObjVars,
         ## hw values
         # hwPt = Var("hwPT_toInt()",int,doc="hardware pt"),
-        hwQual = Var("hwQualityScore_toInt()",int),
+        # hwQual = Var("hwQualityFlags_toInt()",int),
         hwIso = Var("hwIsolationPT_toInt()",int),
         ## more physical values
         ## using the GT scales for HW to physicsal vonversion, see scales in https://github.com/cms-sw/cmssw/blob/master/L1Trigger/Phase2L1GT/python/l1tGTScales.py
@@ -93,7 +93,7 @@ gtTkMuTable = gtTkEleTable.clone(
         z0 = Var("vz",float),
         charge = Var("charge", int, doc="charge id"),
         ## hw
-        hwQual = Var("hwQualityScore_toInt()",int),
+        # hwQual = Var("hwQualityFlags_toInt()",int),
         hwD0 = Var("hwD0_toInt()",int),
         hwZ0 = Var("hwZ0_toInt()",int),
         # hwBeta = Var("hwBeta_toInt()",int)

--- a/python/l1tPh2GTtables_cff.py
+++ b/python/l1tPh2GTtables_cff.py
@@ -112,13 +112,44 @@ gtSaDispMuTable = gtTkMuTable.clone(
     doc = cms.string("GT GMT standalone displaced Muon"),
 )
 
-## GT seededCone puppi Jets
-gtSCJetsTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
-    src = cms.InputTag('l1tGTProducer','CL2Jets'),
+# ## GT seededCone puppi Jets
+# gtSCJetsTable = cms.EDProducer(
+#     # "SimpleCandidateFlatTableProducer",
+#     "SimpleP2GTCandidateFlatTableProducer",
+#     src = cms.InputTag('l1tGTProducer','CL2Jets'),
+#     cut = cms.string(""),
+#     name = cms.string("L1GTscJet"),
+#     doc = cms.string("GT CL2Jets: seededCone Puppi Jets"),
+#     singleton = cms.bool(False), # the number of entries is variable
+#     variables = cms.PSet(
+#         l1GTObjVars,
+#         z0 = Var("vz",float),
+#     )
+# )
+
+## GT seededCone 0.4 puppi Jets
+gtSC4JetsTable = cms.EDProducer(
+    # "SimpleCandidateFlatTableProducer",
+    "SimpleP2GTCandidateFlatTableProducer",
+    src = cms.InputTag('l1tGTProducer','CL2JetsSC4'),
     cut = cms.string(""),
-    name = cms.string("L1GTscJet"),
-    doc = cms.string("GT CL2Jets: seededCone Puppi Jets"),
+    name = cms.string("L1GTsc4Jet"),
+    doc = cms.string("GT CL2JetsSC4: seededCone 0.4 Puppi Jets"),
+    singleton = cms.bool(False), # the number of entries is variable
+    variables = cms.PSet(
+        l1GTObjVars,
+        z0 = Var("vz",float),
+    )
+)
+
+## GT seededCone 0.8 puppi Jets
+gtSC8JetsTable = cms.EDProducer(
+    # "SimpleCandidateFlatTableProducer",
+    "SimpleP2GTCandidateFlatTableProducer",
+    src = cms.InputTag('l1tGTProducer','CL2JetsSC8'),
+    cut = cms.string(""),
+    name = cms.string("L1GTsc8Jet"),
+    doc = cms.string("GT CL2JetsSC8: seededCone 0.8 Puppi Jets"),
     singleton = cms.bool(False), # the number of entries is variable
     variables = cms.PSet(
         l1GTObjVars,
@@ -175,7 +206,9 @@ p2GTL1TablesTask = cms.Task(
     gtTkEleTable,
     gtTkMuTable,
     gtSaMuTable, gtSaDispMuTable,
-    gtSCJetsTable,
+    # gtSCJetsTable,
+    gtSC4JetsTable,
+    gtSC8JetsTable,
     gtNNTauTable,
     gtEtSumTable,
     gtHtSumTable,

--- a/python/l1tPh2GTtables_cff.py
+++ b/python/l1tPh2GTtables_cff.py
@@ -71,7 +71,7 @@ gtTkPhoTable =cms.EDProducer(
         l1GTObjVars,
         ## hw values
         # hwPt = Var("hwPT_toInt()",int,doc="hardware pt"),
-        # hwQual = Var("hwQualityFlags_toInt()",int),
+        hwQual = Var("hwQualityFlags_toInt()",int),
         hwIso = Var("hwIsolationPT_toInt()",int),
         ## more physical values
         ## using the GT scales for HW to physicsal vonversion, see scales in https://github.com/cms-sw/cmssw/blob/master/L1Trigger/Phase2L1GT/python/l1tGTScales.py
@@ -101,7 +101,7 @@ gtTkMuTable = gtTkEleTable.clone(
         z0 = Var("vz",float),
         charge = Var("charge", int, doc="charge id"),
         ## hw
-        # hwQual = Var("hwQualityFlags_toInt()",int),
+        hwQual = Var("hwQualityScore_toInt()",int),
         hwD0 = Var("hwD0_toInt()",int),
         hwZ0 = Var("hwZ0_toInt()",int),
         # hwBeta = Var("hwBeta_toInt()",int)

--- a/python/l1tPh2GTtables_cff.py
+++ b/python/l1tPh2GTtables_cff.py
@@ -11,19 +11,27 @@ l1GTObjVars = cms.PSet(
 )
 
 ### P2GT Algo Block - trigger decisions
-gtAlgoTable = cms.EDProducer(
-    "P2GTAlgoBlockFlatTableProducer",
-    src = cms.InputTag('l1tGTAlgoBlockProducer'),
-    cut = cms.string(""),
-    name = cms.string("L1GT"),
-    doc = cms.string("GT Algo Block decisions"),
-    singleton = cms.bool(False), # the number of entries is variable
-    variables = cms.PSet(
-        # name = Var("algoName",string, doc = "algo name"), # does not work
-        final = Var("decisionFinal",float, doc = "final decision"),
-        initial = Var("decisionBeforeBxMaskAndPrescale",float, doc = "initial decision"),
-    )
+l1tP2GTTrigConvert = cms.EDProducer("P2GTTriggerResultsConverter",
+    src = cms.InputTag("l1tGTAlgoBlockProducer"),
+    prefix = cms.string("L1_"),     # can be anything or omitted, default: "L1_" 
+    decision = cms.string("final"), # can be "beforeBxMaskAndPrescale", "beforePrescale", "final" or omitted, default: "final"
 )
+
+# gtAlgoTable = cms.EDProducer(
+#     "P2GTAlgoBlockFlatTableProducer",
+#     src = cms.InputTag('l1tGTAlgoBlockProducer'),
+#     cut = cms.string(""),
+#     name = cms.string("L1GT"),
+#     doc = cms.string("GT Algo Block decisions"),
+#     singleton = cms.bool(False), # the number of entries is variable
+#     variables = cms.PSet(
+#         # name = Var("algoName",string, doc = "algo name"), # does not work
+#         final = Var("decisionFinal",float, doc = "final decision"),
+#         initial = Var("decisionBeforeBxMaskAndPrescale",float, doc = "initial decision"),
+#     )
+# )
+
+
 
 ### Vertex
 gtVtxTable = cms.EDProducer(
@@ -202,7 +210,7 @@ gtHtSumTable = cms.EDProducer(
 
 ## GT objects
 p2GTL1TablesTask = cms.Task(
-    # gtAlgoTable,
+    l1tP2GTTrigConvert, #gtAlgoTable,
     gtTkPhoTable,
     gtTkEleTable,
     gtTkMuTable,

--- a/python/l1tPh2GTtables_cff.py
+++ b/python/l1tPh2GTtables_cff.py
@@ -173,7 +173,8 @@ gtNNTauTable = cms.EDProducer(
 )
 
 gtEtSumTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    "SimpleP2GTCandidateFlatTableProducer",
     src = cms.InputTag('l1tGTProducer','CL2EtSum'),
     name = cms.string("L1GTpuppiMET"),
     doc = cms.string("GT CL2EtSum"),

--- a/python/l1tPh2GTtables_cff.py
+++ b/python/l1tPh2GTtables_cff.py
@@ -202,7 +202,7 @@ gtHtSumTable = cms.EDProducer(
 
 ## GT objects
 p2GTL1TablesTask = cms.Task(
-    gtAlgoTable,
+    # gtAlgoTable,
     gtTkPhoTable,
     gtTkEleTable,
     gtTkMuTable,

--- a/python/l1tPh2GTtables_cff.py
+++ b/python/l1tPh2GTtables_cff.py
@@ -35,7 +35,6 @@ l1tP2GTTrigConvert = cms.EDProducer("P2GTTriggerResultsConverter",
 
 ### Vertex
 gtVtxTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
     "SimpleP2GTCandidateFlatTableProducer",
     src = cms.InputTag('l1tGTProducer','GTTPrimaryVert'),
     cut = cms.string(""),
@@ -60,7 +59,6 @@ gtPvTable = gtVtxTable.clone(
 
 ### GT
 gtTkPhoTable =cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
     "SimpleP2GTCandidateFlatTableProducer",
     src = cms.InputTag('l1tGTProducer','CL2Photons'),
     name = cms.string("L1GTtkPhoton"),
@@ -137,7 +135,6 @@ gtSaDispMuTable = gtTkMuTable.clone(
 
 ## GT seededCone 0.4 puppi Jets
 gtSC4JetsTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
     "SimpleP2GTCandidateFlatTableProducer",
     src = cms.InputTag('l1tGTProducer','CL2JetsSC4'),
     cut = cms.string(""),
@@ -152,7 +149,6 @@ gtSC4JetsTable = cms.EDProducer(
 
 ## GT seededCone 0.8 puppi Jets
 gtSC8JetsTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
     "SimpleP2GTCandidateFlatTableProducer",
     src = cms.InputTag('l1tGTProducer','CL2JetsSC8'),
     cut = cms.string(""),
@@ -166,7 +162,6 @@ gtSC8JetsTable = cms.EDProducer(
 )
 
 gtNNTauTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
     "SimpleP2GTCandidateFlatTableProducer",
     src = cms.InputTag('l1tGTProducer','CL2Taus'),
     cut = cms.string(""),
@@ -181,7 +176,6 @@ gtNNTauTable = cms.EDProducer(
 )
 
 gtEtSumTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
     "SimpleP2GTCandidateFlatTableProducer",
     src = cms.InputTag('l1tGTProducer','CL2EtSum'),
     name = cms.string("L1GTpuppiMET"),
@@ -194,7 +188,6 @@ gtEtSumTable = cms.EDProducer(
 )
 
 gtHtSumTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
     "SimpleP2GTCandidateFlatTableProducer",
     src = cms.InputTag('l1tGTProducer','CL2HtSum'),
     name = cms.string("L1GTscJetSum"),

--- a/python/l1tPh2Nano_cff.py
+++ b/python/l1tPh2Nano_cff.py
@@ -67,7 +67,7 @@ def addGenObjects(process):
 def addFullPh2L1Nano(process):
     addGenObjects(process)
     addPh2L1Objects(process)
-    addPh2GTObjects(process)
+    # addPh2GTObjects(process)
 
     return process
 

--- a/python/l1tPh2Nano_cff.py
+++ b/python/l1tPh2Nano_cff.py
@@ -67,7 +67,7 @@ def addGenObjects(process):
 def addFullPh2L1Nano(process):
     addGenObjects(process)
     addPh2L1Objects(process)
-    # addPh2GTObjects(process)
+    addPh2GTObjects(process)
 
     return process
 

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -141,8 +141,7 @@ pvtxTable = vtxTable.clone(
 #### EG
 tkPhotonTable = cms.EDProducer(
     # "SimpleCandidateFlatTableProducer",
-    # "SimpleTriggerL1TkEmFlatTableProducer",
-    "SimpleTriggerL1TkElectronFlatTableProducer", #TkElectron also includes trkzVtx needed for the electron table below
+    "SimpleTriggerL1TkEmFlatTableProducer",
     src = cms.InputTag('l1tLayer2EG','L1CtTkEm'),
     cut = cms.string("pt > 5"),
     name = cms.string("L1tkPhoton"),
@@ -162,13 +161,38 @@ tkPhotonTable = cms.EDProducer(
     )
 )
 
-tkEleTable = tkPhotonTable.clone(
+tkEleTable = cms.EDProducer(
+    # "SimpleCandidateFlatTableProducer",
+    # "SimpleTriggerL1TkEmFlatTableProducer",
+    "SimpleTriggerL1TkElectronFlatTableProducer", #TkElectron also includes trkzVtx needed for the electron table below
     src = cms.InputTag('l1tLayer2EG','L1CtTkElectron'),
     name = cms.string("L1tkElectron"),
     doc = cms.string("Tk Electrons"),
+    cut = cms.string("pt > 5"),
+    # singleton = cms.bool(False), # the number of entries is variable
+    variables = cms.PSet(
+        l1ObjVars,
+        relIso = Var("trkIsol", float, doc = "relative Isolation based on trkIsol variable"),
+        # tkIso   = Var("trkIsol", float), ## use above instead to be consistent with the GT and with the tkEle
+        # tkIsoPV  = Var("trkIsolPV", float),
+        # pfIso   = Var("pfIsol", float),
+        # puppiIso  = Var("puppiIsol", float),
+        ## quality WPs, see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePhysicsCutParser#Suppported_operators_and_functio
+        saId   = Var("test_bit(hwQual(),0)", bool, doc = "standalone ID, bit 0 of hwQual"),
+        eleId  = Var("test_bit(hwQual(),1)", bool, doc = "electron ID, bit 1 of hwQual"),
+        phoId  = Var("test_bit(hwQual(),2)", bool, doc = "photon ID, bit 2 of hwQual"),
+        z0     = Var("trkzVtx", float, "track vertex z0"),
+        charge = Var("charge", int, doc="charge"),
+    )
 )
-tkEleTable.variables.z0     = Var("trkzVtx", float, "track vertex z0")
-tkEleTable.variables.charge = Var("charge", int, doc="charge")
+
+# tkEleTable = tkPhotonTable.clone(
+#     src = cms.InputTag('l1tLayer2EG','L1CtTkElectron'),
+#     name = cms.string("L1tkElectron"),
+#     doc = cms.string("Tk Electrons"),
+# )
+# tkEleTable.variables.z0     = Var("trkzVtx", float, "track vertex z0")
+# tkEleTable.variables.charge = Var("charge", int, doc="charge")
 ## additional variables that are not used in the menu/GT
 ## from https://github.com/p2l1pfp/FastPUPPI/blob/12_5_X/NtupleProducer/python/runPerformanceNTuple.py#L499C8-L501C83
 # tkEleTable.variables.tkEta = Var("trkPtr.eta", float,precision=8)

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -86,8 +86,6 @@ gttTripletTable = cms.EDProducer(
 )
 
 gttEtSumTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
-    # "SimpleTriggerL1EtSumFlatTableProducer",
     "SimpleTriggerL1CandidateFlatTableProducer",
     src = cms.InputTag("l1tTrackerEmuEtMiss", "L1TrackerEmuEtMiss"),
     name = cms.string("L1TrackMET"),
@@ -105,8 +103,6 @@ gttEtSumTable = cms.EDProducer(
 )
 
 gttHtSumTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
-    # "SimpleTriggerL1EtSumFlatTableProducer",
     "SimpleTriggerL1CandidateFlatTableProducer",
     src = cms.InputTag("l1tTrackerEmuHTMiss", "L1TrackerEmuHTMiss"),
     name = cms.string("L1TrackHT"),
@@ -140,7 +136,6 @@ pvtxTable = vtxTable.clone(
 
 #### EG
 tkPhotonTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
     "SimpleTriggerL1TkEmFlatTableProducer",
     src = cms.InputTag('l1tLayer2EG','L1CtTkEm'),
     cut = cms.string("pt > 5"),
@@ -162,8 +157,6 @@ tkPhotonTable = cms.EDProducer(
 )
 
 tkEleTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
-    # "SimpleTriggerL1TkEmFlatTableProducer",
     "SimpleTriggerL1TkElectronFlatTableProducer", #TkElectron includes trkzVtx
     src = cms.InputTag('l1tLayer2EG','L1CtTkElectron'),
     name = cms.string("L1tkElectron"),
@@ -218,7 +211,6 @@ staEGmerged = cms.EDProducer("CandViewMerger",
 
 staEGTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
-    # "SimpleTriggerL1EGFlatTableProducer",
     src = cms.InputTag("staEGmerged"),
     cut = cms.string("pt > 5"),
     name = cms.string("L1EG"),
@@ -238,7 +230,6 @@ staEGTable = cms.EDProducer(
 )
 
 staEGebTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
     "SimpleTriggerL1EGFlatTableProducer",
     src = cms.InputTag('l1tPhase2L1CaloEGammaEmulator','GCTEGammas'),
     cut = cms.string("pt > 5"),
@@ -266,7 +257,6 @@ staEGeeTable =  staEGebTable.clone(
 ### Muons
 
 staMuTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
     "SimpleTriggerL1SAMuonFlatTableProducer",
     src = cms.InputTag('l1tSAMuonsGmt','prompt'),
     name = cms.string("L1gmtMuon"),
@@ -308,7 +298,6 @@ staDisplacedMuTable = staMuTable.clone(
 )
 
 gmtTkMuTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
     "SimpleTriggerL1TrackerMuonFlatTableProducer",
     src = cms.InputTag('l1tTkMuonsGmt'),
     name = cms.string("L1gmtTkMuon"),
@@ -404,7 +393,6 @@ EMTFDisplaceMuTable = staMuTable.clone(
 ### Jets
 sc4JetTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
-    # "SimpleTriggerL1PFJetFlatTableProducer",
     src = cms.InputTag('l1tSC4PFL1PuppiCorrectedEmulator'),
     cut = cms.string(""),
     name = cms.string("L1puppiJetSC4"),
@@ -451,7 +439,6 @@ caloJetTable = sc4JetTable.clone(
 
 puppiMetTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
-    # "SimpleTriggerL1EtSumFlatTableProducer",
     src = cms.InputTag("l1tMETPFProducer",""),
     name = cms.string("L1puppiMET"),
     doc = cms.string("Puppi MET, origin: Correlator"),
@@ -464,8 +451,6 @@ puppiMetTable = cms.EDProducer(
 
 puppiMLMetTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
-    # "SimpleTriggerL1MetPfFlatTableProducer",
-    # "SimpleTriggerL1EtSumFlatTableProducer",
     src = cms.InputTag("l1tMETMLProducer",""),
     name = cms.string("L1puppiMLMET"),
     doc = cms.string("Puppi ML MET, origin: Correlator"),
@@ -478,8 +463,6 @@ puppiMLMetTable = cms.EDProducer(
 
 sc4SumsTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
-    # "SimpleTriggerL1EtSumFlatTableProducer",
-    # "SimpleTriggerL1CandidateFlatTableProducer",
     src = cms.InputTag("l1tSC4PFL1PuppiCorrectedEmulatorMHT",""),
     name = cms.string("L1puppiJetSC4sums"),
     doc = cms.string("HT and MHT from SeededCone Radius 0.8 jets; idx 0 is HT, idx 1 is MHT, origin: Correlator"),
@@ -500,7 +483,6 @@ histoSumsTable = sc4SumsTable.clone(
 
 ### Taus
 caloTauTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
     "SimpleTriggerL1CaloJetFlatTableProducer",
     src = cms.InputTag("l1tPhase2CaloJetEmulator","GCTJet"),
     cut = cms.string("pt > 5"),
@@ -516,8 +498,6 @@ caloTauTable = cms.EDProducer(
 
 
 nnCaloTauTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
-    # "SimpleTriggerL1TauFlatTableProducer",
     "SimpleTriggerL1CandidateFlatTableProducer",
     src = cms.InputTag("l1tNNCaloTauEmulator","L1NNCaloTauCollectionBXV"),
     cut = cms.string("pt > 5"),
@@ -532,7 +512,6 @@ nnCaloTauTable = cms.EDProducer(
 )
 
 nnPuppiTauTable = cms.EDProducer(
-    # "SimpleCandidateFlatTableProducer",
     "SimpleTriggerL1PFTauFlatTableProducer",
     src = cms.InputTag("l1tNNTauProducerPuppi","L1PFTausNN"),
     cut = cms.string(""),
@@ -559,9 +538,7 @@ nnPuppiTauTable = cms.EDProducer(
 )
 
 hpsTauTable = cms.EDProducer(
-     # "SimpleCandidateFlatTableProducer",
     "SimpleTriggerL1HPSPFTauFlatTableProducer",
-    # src = cms.InputTag("l1tHPSPFTauEmuProducer","HPSTaus"),
     src = cms.InputTag("l1tHPSPFTauProducerPF",""),
     cut = cms.string(""),
     name = cms.string("L1hpsTau"),

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -559,9 +559,9 @@ nnPuppiTauTable = cms.EDProducer(
 )
 
 hpsTauTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
-    # "SimpleTriggerL1HPSPFTauFlatTableProducer",
-    src = cms.InputTag("l1HPSPFTauEmuProducer","HPSTaus"),
+     # "SimpleCandidateFlatTableProducer",
+    "SimpleTriggerL1HPSPFTauFlatTableProducer",
+    src = cms.InputTag("l1tHPSPFTauEmuProducer","HPSTaus"),
     cut = cms.string(""),
     name = cms.string("L1hpsTau"),
     doc = cms.string("HPS Taus"),
@@ -602,7 +602,7 @@ p2L1TablesTask = cms.Task(
     caloTauTable,
     nnCaloTauTable,
     nnPuppiTauTable,
-    hpsTauTable,
+    # hpsTauTable,
     # GTT
     vtxTable,
     pvtxTable,

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -86,7 +86,9 @@ gttTripletTable = cms.EDProducer(
 )
 
 gttEtSumTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    # "SimpleTriggerL1EtSumFlatTableProducer",
+    "SimpleTriggerL1CandidateFlatTableProducer",
     src = cms.InputTag("l1tTrackerEmuEtMiss", "L1TrackerEmuEtMiss"),
     name = cms.string("L1TrackMET"),
     doc = cms.string("GTT Track MET"),
@@ -103,7 +105,9 @@ gttEtSumTable = cms.EDProducer(
 )
 
 gttHtSumTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    # "SimpleTriggerL1EtSumFlatTableProducer",
+    "SimpleTriggerL1CandidateFlatTableProducer",
     src = cms.InputTag("l1tTrackerEmuHTMiss", "L1TrackerEmuHTMiss"),
     name = cms.string("L1TrackHT"),
     doc = cms.string("GTT Track Missing HT"),
@@ -136,12 +140,14 @@ pvtxTable = vtxTable.clone(
 
 #### EG
 tkPhotonTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    # "SimpleTriggerL1TkEmFlatTableProducer",
+    "SimpleTriggerL1TkElectronFlatTableProducer", #TkElectron also includes trkzVtx needed for the electron table below
     src = cms.InputTag('l1tLayer2EG','L1CtTkEm'),
     cut = cms.string("pt > 5"),
     name = cms.string("L1tkPhoton"),
     doc = cms.string("Tk Photons (EM)"),
-    singleton = cms.bool(False), # the number of entries is variable
+    # singleton = cms.bool(False), # the number of entries is variable
     variables = cms.PSet(
         l1ObjVars,
         relIso = Var("trkIsol", float, doc = "relative Isolation based on trkIsol variable"),
@@ -188,6 +194,7 @@ staEGmerged = cms.EDProducer("CandViewMerger",
 
 staEGTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
+    # "SimpleTriggerL1EGFlatTableProducer",
     src = cms.InputTag("staEGmerged"),
     cut = cms.string("pt > 5"),
     name = cms.string("L1EG"),
@@ -207,7 +214,8 @@ staEGTable = cms.EDProducer(
 )
 
 staEGebTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    "SimpleTriggerL1EGFlatTableProducer",
     src = cms.InputTag('l1tPhase2L1CaloEGammaEmulator','GCTEGammas'),
     cut = cms.string("pt > 5"),
     name = cms.string("L1EGbarrel"),
@@ -234,12 +242,13 @@ staEGeeTable =  staEGebTable.clone(
 ### Muons
 
 staMuTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    "SimpleTriggerL1SAMuonFlatTableProducer",
     src = cms.InputTag('l1tSAMuonsGmt','prompt'),
     name = cms.string("L1gmtMuon"),
     doc = cms.string("GMT standalone Muons, origin: GMT"),
     cut = cms.string(""),
-    singleton = cms.bool(False), # the number of entries is variable
+    # singleton = cms.bool(False), # the number of entries is variable
     variables = cms.PSet(
         # l1ObjVars,
         ### WARNING : the pt/eta/phi/vz methods give rounded results -> use the "physical" accessors
@@ -329,6 +338,7 @@ EMTFDisplaceMuTable = staMuTable.clone(
 ### Jets
 sc4JetTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
+    # "SimpleTriggerL1PFJetFlatTableProducer",
     src = cms.InputTag('l1tSC4PFL1PuppiCorrectedEmulator'),
     cut = cms.string(""),
     name = cms.string("L1puppiJetSC4"),
@@ -375,6 +385,7 @@ caloJetTable = sc4JetTable.clone(
 
 puppiMetTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
+    # "SimpleTriggerL1EtSumFlatTableProducer",
     src = cms.InputTag("l1tMETPFProducer",""),
     name = cms.string("L1puppiMET"),
     doc = cms.string("Puppi MET, origin: Correlator"),
@@ -387,6 +398,8 @@ puppiMetTable = cms.EDProducer(
 
 puppiMLMetTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
+    # "SimpleTriggerL1MetPfFlatTableProducer",
+    # "SimpleTriggerL1EtSumFlatTableProducer",
     src = cms.InputTag("l1tMETMLProducer",""),
     name = cms.string("L1puppiMLMET"),
     doc = cms.string("Puppi ML MET, origin: Correlator"),
@@ -399,6 +412,8 @@ puppiMLMetTable = cms.EDProducer(
 
 sc4SumsTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
+    # "SimpleTriggerL1EtSumFlatTableProducer",
+    # "SimpleTriggerL1CandidateFlatTableProducer",
     src = cms.InputTag("l1tSC4PFL1PuppiCorrectedEmulatorMHT",""),
     name = cms.string("L1puppiJetSC4sums"),
     doc = cms.string("HT and MHT from SeededCone Radius 0.8 jets; idx 0 is HT, idx 1 is MHT, origin: Correlator"),
@@ -419,12 +434,13 @@ histoSumsTable = sc4SumsTable.clone(
 
 ### Taus
 caloTauTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    "SimpleTriggerL1CaloJetFlatTableProducer",
     src = cms.InputTag("l1tPhase2CaloJetEmulator","GCTJet"),
     cut = cms.string("pt > 5"),
     name = cms.string("L1caloTau"),
     doc = cms.string("Calo Taus"),
-    singleton = cms.bool(False), # the number of entries is variable
+    # singleton = cms.bool(False), # the number of entries is variable
     variables = cms.PSet(
         pt  = Var("tauEt",  float, precision=l1_float_precision_), # Define as pt in nano, as required by menu tools downstream
         phi = Var("phi", float, precision=l1_float_precision_),
@@ -434,7 +450,9 @@ caloTauTable = cms.EDProducer(
 
 
 nnCaloTauTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    # "SimpleTriggerL1TauFlatTableProducer",
+    "SimpleTriggerL1CandidateFlatTableProducer",
     src = cms.InputTag("l1tNNCaloTauEmulator","L1NNCaloTauCollectionBXV"),
     cut = cms.string("pt > 5"),
     name = cms.string("L1nnCaloTau"),
@@ -448,12 +466,13 @@ nnCaloTauTable = cms.EDProducer(
 )
 
 nnPuppiTauTable = cms.EDProducer(
-    "SimpleCandidateFlatTableProducer",
+    # "SimpleCandidateFlatTableProducer",
+    "SimpleTriggerL1PFTauFlatTableProducer",
     src = cms.InputTag("l1tNNTauProducerPuppi","L1PFTausNN"),
     cut = cms.string(""),
     name = cms.string("L1nnPuppiTau"),
     doc = cms.string("NN Puppi Taus"),
-    singleton = cms.bool(False), # the number of entries is variable
+    # singleton = cms.bool(False), # the number of entries is variable
     variables = cms.PSet(
         l1P3Vars,
         charge = Var("charge", int),
@@ -475,6 +494,7 @@ nnPuppiTauTable = cms.EDProducer(
 
 hpsTauTable = cms.EDProducer(
     "SimpleCandidateFlatTableProducer",
+    # "SimpleTriggerL1HPSPFTauFlatTableProducer",
     src = cms.InputTag("l1HPSPFTauEmuProducer","HPSTaus"),
     cut = cms.string(""),
     name = cms.string("L1hpsTau"),

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -306,16 +306,58 @@ staDisplacedMuTable = staMuTable.clone(
     name = cms.string("L1gmtDispMuon"),
     doc = cms.string("GMT standalone displaced Muons, origin: GMT"),
 )
-gmtTkMuTable = staMuTable.clone(
+
+gmtTkMuTable = cms.EDProducer(
+    # "SimpleCandidateFlatTableProducer",
+    "SimpleTriggerL1TrackerMuonFlatTableProducer",
     src = cms.InputTag('l1tTkMuonsGmt'),
     name = cms.string("L1gmtTkMuon"),
     doc = cms.string("GMT Tk Muons, origin: GMT"),
+    cut = cms.string(""),
+    # singleton = cms.bool(False), # the number of entries is variable
+    variables = cms.PSet(
+        # l1ObjVars,
+        ### WARNING : the pt/eta/phi/vz methods give rounded results -> use the "physical" accessors
+        # vz = Var("vz",float),
+        chargeNoPh = Var("charge", int, doc="charge id"),
+
+        ## physical values
+        charge  = Var("phCharge", int, doc="charge id"),
+        pt  = Var("phPt()",float),
+        eta = Var("phEta()",float),
+        phi = Var("phPhi()",float),
+        z0 = Var("phZ0()",float),
+        d0 = Var("phD0()",float),
+        # beta = Var("phBeta()",float), # does not exist
+
+        ## hw Values
+        hwPt = Var("hwPt()",int,doc="hardware pt"),
+        hwEta = Var("hwEta()",int,doc="hardware eta"),
+        hwPhi = Var("hwPhi()",int,doc="hardware phi"),
+        hwQual = Var("hwQual()",int,doc="hardware qual"),
+        hwIso = Var("hwIso()",int,doc="hardware iso"),
+        hwBeta = Var("hwBeta()",int,doc="hardware beta"),
+        vlooseId  = Var("test_bit(hwQual(),0)", bool, doc = "VLoose ID, bit 0 of hwQual"),
+        looseId   = Var("test_bit(hwQual(),1)", bool, doc = "Loose ID, bit 1 of hwQual"),
+        mediumId  = Var("test_bit(hwQual(),2)", bool, doc = "Medium ID, bit 2 of hwQual"),
+        tightId   = Var("test_bit(hwQual(),3)", bool, doc = "Tight ID, bit 3 of hwQual")
+
+        # ## more info
+        # nStubs = Var("stubs().size()",int,doc="number of stubs"),
+    )
 )
+
+
+# gmtTkMuTable = staMuTable.clone(
+#     src = cms.InputTag('l1tTkMuonsGmt'),
+#     name = cms.string("L1gmtTkMuon"),
+#     doc = cms.string("GMT Tk Muons, origin: GMT"),
+# )
 # gmtTkMuTable.variables.nStubs = Var("stubs().size()",int,doc="number of stubs")
-gmtTkMuTable.variables.vlooseId  = Var("test_bit(hwQual(),0)", bool, doc = "VLoose ID, bit 0 of hwQual")
-gmtTkMuTable.variables.looseId   = Var("test_bit(hwQual(),1)", bool, doc = "Loose ID, bit 1 of hwQual")
-gmtTkMuTable.variables.mediumId  = Var("test_bit(hwQual(),2)", bool, doc = "Medium ID, bit 2 of hwQual")
-gmtTkMuTable.variables.tightId   = Var("test_bit(hwQual(),3)", bool, doc = "Tight ID, bit 3 of hwQual")
+# gmtTkMuTable.variables.vlooseId  = Var("test_bit(hwQual(),0)", bool, doc = "VLoose ID, bit 0 of hwQual")
+# gmtTkMuTable.variables.looseId   = Var("test_bit(hwQual(),1)", bool, doc = "Loose ID, bit 1 of hwQual")
+# gmtTkMuTable.variables.mediumId  = Var("test_bit(hwQual(),2)", bool, doc = "Medium ID, bit 2 of hwQual")
+# gmtTkMuTable.variables.tightId   = Var("test_bit(hwQual(),3)", bool, doc = "Tight ID, bit 3 of hwQual")
 
 ### Standalone Muon from GMT, before ghost busting
 

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -164,7 +164,7 @@ tkPhotonTable = cms.EDProducer(
 tkEleTable = cms.EDProducer(
     # "SimpleCandidateFlatTableProducer",
     # "SimpleTriggerL1TkEmFlatTableProducer",
-    "SimpleTriggerL1TkElectronFlatTableProducer", #TkElectron also includes trkzVtx needed for the electron table below
+    "SimpleTriggerL1TkElectronFlatTableProducer", #TkElectron includes trkzVtx
     src = cms.InputTag('l1tLayer2EG','L1CtTkElectron'),
     name = cms.string("L1tkElectron"),
     doc = cms.string("Tk Electrons"),

--- a/python/l1tPh2Nanotables_cff.py
+++ b/python/l1tPh2Nanotables_cff.py
@@ -561,7 +561,8 @@ nnPuppiTauTable = cms.EDProducer(
 hpsTauTable = cms.EDProducer(
      # "SimpleCandidateFlatTableProducer",
     "SimpleTriggerL1HPSPFTauFlatTableProducer",
-    src = cms.InputTag("l1tHPSPFTauEmuProducer","HPSTaus"),
+    # src = cms.InputTag("l1tHPSPFTauEmuProducer","HPSTaus"),
+    src = cms.InputTag("l1tHPSPFTauProducerPF",""),
     cut = cms.string(""),
     name = cms.string("L1hpsTau"),
     doc = cms.string("HPS Taus"),
@@ -602,7 +603,7 @@ p2L1TablesTask = cms.Task(
     caloTauTable,
     nnCaloTauTable,
     nnPuppiTauTable,
-    # hpsTauTable,
+    hpsTauTable,
     # GTT
     vtxTable,
     pvtxTable,

--- a/test/v43_rerunL1noTT_cfg.py
+++ b/test/v43_rerunL1noTT_cfg.py
@@ -2,7 +2,7 @@
 # using: 
 # Revision: 1.19 
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
-# with command line options: l1nanoPhase2_noTT -s L1,USER:PhysicsTools/L1Nano/l1tPh2Nano_cff.l1tPh2NanoTask --customise PhysicsTools/L1Nano/l1tPh2Nano_cff.addFullPh2L1Nano --conditions auto:phase2_realistic_T33 --geometry Extended2026D110 --era Phase2C17I13M9 --eventcontent NANOAOD --datatier GEN-SIM-DIGI-RAW-MINIAOD --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring --filein /store/mc/Phase2Spring24DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_AllTP_140X_mcRun4_realistic_v4-v1/2560000/11d1f6f0-5f03-421e-90c7-b5815197fc85.root --fileout file:output_Phase2_L1T.root --python_filename rerunL1_cfg.py --inputCommands=keep *, drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT --mc -n 1 --nThreads 1
+# with command line options: l1nanoPhase2_noTT -s L1,L1P2GT,USER:PhysicsTools/L1Nano/l1tPh2Nano_cff.l1tPh2NanoTask --customise PhysicsTools/L1Nano/l1tPh2Nano_cff.addFullPh2L1Nano --conditions auto:phase2_realistic_T33 --geometry Extended2026D110 --era Phase2C17I13M9 --eventcontent NANOAOD --datatier GEN-SIM-DIGI-RAW-MINIAOD --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2.addHcalTriggerPrimitives --filein /store/mc/Phase2Spring24DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_AllTP_140X_mcRun4_realistic_v4-v1/2560000/11d1f6f0-5f03-421e-90c7-b5815197fc85.root --fileout file:output_Phase2_L1T.root --python_filename rerunL1_cfg.py --inputCommands=keep *, drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT --mc -n 1 --nThreads 1
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
@@ -18,6 +18,8 @@ process.load('SimGeneral.MixingModule.mixNoPU_cfi')
 process.load('Configuration.Geometry.GeometryExtended2026D110Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.SimL1Emulator_cff')
+process.load('Configuration.StandardSequences.SimPhase2L1GlobalTriggerEmulator_cff')
+process.load('L1Trigger.Configuration.Phase2GTMenus.SeedDefinitions.prototypeSeeds')
 process.load('PhysicsTools.L1Nano.l1tPh2Nano_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
@@ -99,12 +101,55 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', ''
 
 # Path and EndPath definitions
 process.L1simulation_step = cms.Path(process.SimL1Emulator)
+process.Phase2L1GTProducer = cms.Path(process.l1tGTProducerSequence)
+process.Phase2L1GTAlgoBlockProducer = cms.Path(process.l1tGTAlgoBlockProducerSequence)
+process.TripleTkMuon_5_3_0_DoubleTkMuon_5_3_OS_MassTo9 = cms.Path(process.TripleTkMuon530OSMassMax9)
+process.TripleTkMuon_5_3p5_2p5_OS_Mass5to17 = cms.Path(process.TripleTkMuon53p52p5OSMass5to17)
+process.pDoubleEGEle37_24 = cms.Path(process.DoubleEGEle3724)
+process.pDoubleIsoTkPho22_12 = cms.Path(process.DoubleIsoTkPho2212)
+process.pDoublePuppiJet112_112 = cms.Path(process.DoublePuppiJet112112)
+process.pDoublePuppiJet160_35_mass620 = cms.Path(process.DoublePuppiJet16035Mass620)
+process.pDoublePuppiTau52_52 = cms.Path(process.DoublePuppiTau5252)
+process.pDoubleTkEle25_12 = cms.Path(process.DoubleTkEle2512)
+process.pDoubleTkElePuppiHT_8_8_390 = cms.Path(process.DoubleTkElePuppiHT)
+process.pDoubleTkMuPuppiHT_3_3_300 = cms.Path(process.DoubleTkMuPuppiHT)
+process.pDoubleTkMuPuppiJetPuppiMet_3_3_60_130 = cms.Path(process.DoubleTkMuPuppiJetPuppiMet)
+process.pDoubleTkMuon15_7 = cms.Path(process.DoubleTkMuon157)
+process.pDoubleTkMuonTkEle5_5_9 = cms.Path(process.DoubleTkMuonTkEle559)
+process.pDoubleTkMuon_4_4_OS_Dr1p2 = cms.Path(process.DoubleTkMuon44OSDr1p2)
+process.pDoubleTkMuon_4p5_4p5_OS_Er2_Mass7to18 = cms.Path(process.DoubleTkMuon4p5OSEr2Mass7to18)
+process.pDoubleTkMuon_OS_Er1p5_Dr1p4 = cms.Path(process.DoubleTkMuonOSEr1p5Dr1p4)
+process.pIsoTkEleEGEle22_12 = cms.Path(process.IsoTkEleEGEle2212)
+process.pNNPuppiTauPuppiMet_55_190 = cms.Path(process.NNPuppiTauPuppiMet)
+process.pPuppiHT400 = cms.Path(process.PuppiHT400)
+process.pPuppiHT450 = cms.Path(process.PuppiHT450)
+process.pPuppiMET200 = cms.Path(process.PuppiMET200)
+process.pPuppiMHT140 = cms.Path(process.PuppiMHT140)
+process.pPuppiTauTkIsoEle45_22 = cms.Path(process.PuppiTauTkIsoEle4522)
+process.pPuppiTauTkMuon42_18 = cms.Path(process.PuppiTauTkMuon4218)
+process.pQuadJet70_55_40_40 = cms.Path(process.QuadJet70554040)
+process.pSingleEGEle51 = cms.Path(process.SingleEGEle51)
+process.pSingleIsoTkEle28 = cms.Path(process.SingleIsoTkEle28)
+process.pSingleIsoTkPho36 = cms.Path(process.SingleIsoTkPho36)
+process.pSinglePuppiJet230 = cms.Path(process.SinglePuppiJet230)
+process.pSingleTkEle36 = cms.Path(process.SingleTkEle36)
+process.pSingleTkMuon22 = cms.Path(process.SingleTkMuon22)
+process.pTkEleIsoPuppiHT_26_190 = cms.Path(process.TkEleIsoPuppiHT)
+process.pTkElePuppiJet_28_40_MinDR = cms.Path(process.TkElePuppiJetMinDR)
+process.pTkEleTkMuon10_20 = cms.Path(process.TkEleTkMuon1020)
+process.pTkMuPuppiJetPuppiMet_3_110_120 = cms.Path(process.TkMuPuppiJetPuppiMet)
+process.pTkMuTriPuppiJet_12_40_dRMax_DoubleJet_dEtaMax = cms.Path(process.TkMuTriPuppiJetdRMaxDoubleJetdEtaMax)
+process.pTkMuonDoubleTkEle6_17_17 = cms.Path(process.TkMuonDoubleTkEle61717)
+process.pTkMuonPuppiHT6_320 = cms.Path(process.TkMuonPuppiHT6320)
+process.pTkMuonTkEle7_23 = cms.Path(process.TkMuonTkEle723)
+process.pTkMuonTkIsoEle7_20 = cms.Path(process.TkMuonTkIsoEle720)
+process.pTripleTkMuon5_3_3 = cms.Path(process.TripleTkMuon533)
 process.user_step = cms.Path(process.l1tPh2NanoTask)
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.NANOAODoutput_step = cms.EndPath(process.NANOAODoutput)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.L1simulation_step,process.user_step,process.endjob_step,process.NANOAODoutput_step)
+process.schedule = cms.Schedule(process.L1simulation_step,process.Phase2L1GTProducer,process.Phase2L1GTAlgoBlockProducer,process.TripleTkMuon_5_3_0_DoubleTkMuon_5_3_OS_MassTo9,process.TripleTkMuon_5_3p5_2p5_OS_Mass5to17,process.pDoubleEGEle37_24,process.pDoubleIsoTkPho22_12,process.pDoublePuppiJet112_112,process.pDoublePuppiJet160_35_mass620,process.pDoublePuppiTau52_52,process.pDoubleTkEle25_12,process.pDoubleTkElePuppiHT_8_8_390,process.pDoubleTkMuPuppiHT_3_3_300,process.pDoubleTkMuPuppiJetPuppiMet_3_3_60_130,process.pDoubleTkMuon15_7,process.pDoubleTkMuonTkEle5_5_9,process.pDoubleTkMuon_4_4_OS_Dr1p2,process.pDoubleTkMuon_4p5_4p5_OS_Er2_Mass7to18,process.pDoubleTkMuon_OS_Er1p5_Dr1p4,process.pIsoTkEleEGEle22_12,process.pNNPuppiTauPuppiMet_55_190,process.pPuppiHT400,process.pPuppiHT450,process.pPuppiMET200,process.pPuppiMHT140,process.pPuppiTauTkIsoEle45_22,process.pPuppiTauTkMuon42_18,process.pQuadJet70_55_40_40,process.pSingleEGEle51,process.pSingleIsoTkEle28,process.pSingleIsoTkPho36,process.pSinglePuppiJet230,process.pSingleTkEle36,process.pSingleTkMuon22,process.pTkEleIsoPuppiHT_26_190,process.pTkElePuppiJet_28_40_MinDR,process.pTkEleTkMuon10_20,process.pTkMuPuppiJetPuppiMet_3_110_120,process.pTkMuTriPuppiJet_12_40_dRMax_DoubleJet_dEtaMax,process.pTkMuonDoubleTkEle6_17_17,process.pTkMuonPuppiHT6_320,process.pTkMuonTkEle7_23,process.pTkMuonTkIsoEle7_20,process.pTripleTkMuon5_3_3,process.user_step,process.endjob_step,process.NANOAODoutput_step)
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)
 
@@ -127,6 +172,12 @@ from Configuration.DataProcessing.Utils import addMonitoring
 
 #call to customisation function addMonitoring imported from Configuration.DataProcessing.Utils
 process = addMonitoring(process)
+
+# Automatic addition of the customisation function from L1Trigger.Configuration.customisePhase2
+from L1Trigger.Configuration.customisePhase2 import addHcalTriggerPrimitives 
+
+#call to customisation function addHcalTriggerPrimitives imported from L1Trigger.Configuration.customisePhase2
+process = addHcalTriggerPrimitives(process)
 
 # End of customisation functions
 

--- a/test/v43_rerunL1wTT_cfg.py
+++ b/test/v43_rerunL1wTT_cfg.py
@@ -2,7 +2,7 @@
 # using: 
 # Revision: 1.19 
 # Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
-# with command line options: l1nanoPhase2 -s L1,L1TrackTrigger,USER:PhysicsTools/L1Nano/l1tPh2Nano_cff.l1tPh2NanoTask --customise PhysicsTools/L1Nano/l1tPh2Nano_cff.addFullPh2L1Nano --conditions auto:phase2_realistic_T33 --geometry Extended2026D110 --era Phase2C17I13M9 --eventcontent NANOAOD --datatier GEN-SIM-DIGI-RAW-MINIAOD --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2TTOn110.customisePhase2TTOn110 --filein /store/mc/Phase2Spring24DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_AllTP_140X_mcRun4_realistic_v4-v1/2560000/11d1f6f0-5f03-421e-90c7-b5815197fc85.root --fileout file:output_Phase2_L1T.root --python_filename rerunL1_cfg.py --inputCommands=keep *, drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT --mc -n 1 --nThreads 1
+# with command line options: l1nanoPhase2 -s L1,L1TrackTrigger,L1P2GT,USER:PhysicsTools/L1Nano/l1tPh2Nano_cff.l1tPh2NanoTask --customise PhysicsTools/L1Nano/l1tPh2Nano_cff.addFullPh2L1Nano --conditions auto:phase2_realistic_T33 --geometry Extended2026D110 --era Phase2C17I13M9 --eventcontent NANOAOD --datatier GEN-SIM-DIGI-RAW-MINIAOD --customise SLHCUpgradeSimulations/Configuration/aging.customise_aging_1000,Configuration/DataProcessing/Utils.addMonitoring,L1Trigger/Configuration/customisePhase2TTOn110.customisePhase2TTOn110 --filein /store/mc/Phase2Spring24DIGIRECOMiniAOD/TT_TuneCP5_14TeV-powheg-pythia8/GEN-SIM-DIGI-RAW-MINIAOD/PU200_AllTP_140X_mcRun4_realistic_v4-v1/2560000/11d1f6f0-5f03-421e-90c7-b5815197fc85.root --fileout file:output_Phase2_L1T.root --python_filename rerunL1_cfg.py --inputCommands=keep *, drop l1tPFJets_*_*_*, drop l1tTrackerMuons_l1tTkMuonsGmt*_*_HLT --mc -n 1 --nThreads 1
 import FWCore.ParameterSet.Config as cms
 
 from Configuration.Eras.Era_Phase2C17I13M9_cff import Phase2C17I13M9
@@ -19,6 +19,8 @@ process.load('Configuration.Geometry.GeometryExtended2026D110Reco_cff')
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.SimL1Emulator_cff')
 process.load('Configuration.StandardSequences.L1TrackTrigger_cff')
+process.load('Configuration.StandardSequences.SimPhase2L1GlobalTriggerEmulator_cff')
+process.load('L1Trigger.Configuration.Phase2GTMenus.SeedDefinitions.prototypeSeeds')
 process.load('PhysicsTools.L1Nano.l1tPh2Nano_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
@@ -101,12 +103,55 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic_T33', ''
 # Path and EndPath definitions
 process.L1simulation_step = cms.Path(process.SimL1Emulator)
 process.L1TrackTrigger_step = cms.Path(process.L1TrackTrigger)
+process.Phase2L1GTProducer = cms.Path(process.l1tGTProducerSequence)
+process.Phase2L1GTAlgoBlockProducer = cms.Path(process.l1tGTAlgoBlockProducerSequence)
+process.TripleTkMuon_5_3_0_DoubleTkMuon_5_3_OS_MassTo9 = cms.Path(process.TripleTkMuon530OSMassMax9)
+process.TripleTkMuon_5_3p5_2p5_OS_Mass5to17 = cms.Path(process.TripleTkMuon53p52p5OSMass5to17)
+process.pDoubleEGEle37_24 = cms.Path(process.DoubleEGEle3724)
+process.pDoubleIsoTkPho22_12 = cms.Path(process.DoubleIsoTkPho2212)
+process.pDoublePuppiJet112_112 = cms.Path(process.DoublePuppiJet112112)
+process.pDoublePuppiJet160_35_mass620 = cms.Path(process.DoublePuppiJet16035Mass620)
+process.pDoublePuppiTau52_52 = cms.Path(process.DoublePuppiTau5252)
+process.pDoubleTkEle25_12 = cms.Path(process.DoubleTkEle2512)
+process.pDoubleTkElePuppiHT_8_8_390 = cms.Path(process.DoubleTkElePuppiHT)
+process.pDoubleTkMuPuppiHT_3_3_300 = cms.Path(process.DoubleTkMuPuppiHT)
+process.pDoubleTkMuPuppiJetPuppiMet_3_3_60_130 = cms.Path(process.DoubleTkMuPuppiJetPuppiMet)
+process.pDoubleTkMuon15_7 = cms.Path(process.DoubleTkMuon157)
+process.pDoubleTkMuonTkEle5_5_9 = cms.Path(process.DoubleTkMuonTkEle559)
+process.pDoubleTkMuon_4_4_OS_Dr1p2 = cms.Path(process.DoubleTkMuon44OSDr1p2)
+process.pDoubleTkMuon_4p5_4p5_OS_Er2_Mass7to18 = cms.Path(process.DoubleTkMuon4p5OSEr2Mass7to18)
+process.pDoubleTkMuon_OS_Er1p5_Dr1p4 = cms.Path(process.DoubleTkMuonOSEr1p5Dr1p4)
+process.pIsoTkEleEGEle22_12 = cms.Path(process.IsoTkEleEGEle2212)
+process.pNNPuppiTauPuppiMet_55_190 = cms.Path(process.NNPuppiTauPuppiMet)
+process.pPuppiHT400 = cms.Path(process.PuppiHT400)
+process.pPuppiHT450 = cms.Path(process.PuppiHT450)
+process.pPuppiMET200 = cms.Path(process.PuppiMET200)
+process.pPuppiMHT140 = cms.Path(process.PuppiMHT140)
+process.pPuppiTauTkIsoEle45_22 = cms.Path(process.PuppiTauTkIsoEle4522)
+process.pPuppiTauTkMuon42_18 = cms.Path(process.PuppiTauTkMuon4218)
+process.pQuadJet70_55_40_40 = cms.Path(process.QuadJet70554040)
+process.pSingleEGEle51 = cms.Path(process.SingleEGEle51)
+process.pSingleIsoTkEle28 = cms.Path(process.SingleIsoTkEle28)
+process.pSingleIsoTkPho36 = cms.Path(process.SingleIsoTkPho36)
+process.pSinglePuppiJet230 = cms.Path(process.SinglePuppiJet230)
+process.pSingleTkEle36 = cms.Path(process.SingleTkEle36)
+process.pSingleTkMuon22 = cms.Path(process.SingleTkMuon22)
+process.pTkEleIsoPuppiHT_26_190 = cms.Path(process.TkEleIsoPuppiHT)
+process.pTkElePuppiJet_28_40_MinDR = cms.Path(process.TkElePuppiJetMinDR)
+process.pTkEleTkMuon10_20 = cms.Path(process.TkEleTkMuon1020)
+process.pTkMuPuppiJetPuppiMet_3_110_120 = cms.Path(process.TkMuPuppiJetPuppiMet)
+process.pTkMuTriPuppiJet_12_40_dRMax_DoubleJet_dEtaMax = cms.Path(process.TkMuTriPuppiJetdRMaxDoubleJetdEtaMax)
+process.pTkMuonDoubleTkEle6_17_17 = cms.Path(process.TkMuonDoubleTkEle61717)
+process.pTkMuonPuppiHT6_320 = cms.Path(process.TkMuonPuppiHT6320)
+process.pTkMuonTkEle7_23 = cms.Path(process.TkMuonTkEle723)
+process.pTkMuonTkIsoEle7_20 = cms.Path(process.TkMuonTkIsoEle720)
+process.pTripleTkMuon5_3_3 = cms.Path(process.TripleTkMuon533)
 process.user_step = cms.Path(process.l1tPh2NanoTask)
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.NANOAODoutput_step = cms.EndPath(process.NANOAODoutput)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.L1simulation_step,process.L1TrackTrigger_step,process.user_step,process.endjob_step,process.NANOAODoutput_step)
+process.schedule = cms.Schedule(process.L1simulation_step,process.L1TrackTrigger_step,process.Phase2L1GTProducer,process.Phase2L1GTAlgoBlockProducer,process.TripleTkMuon_5_3_0_DoubleTkMuon_5_3_OS_MassTo9,process.TripleTkMuon_5_3p5_2p5_OS_Mass5to17,process.pDoubleEGEle37_24,process.pDoubleIsoTkPho22_12,process.pDoublePuppiJet112_112,process.pDoublePuppiJet160_35_mass620,process.pDoublePuppiTau52_52,process.pDoubleTkEle25_12,process.pDoubleTkElePuppiHT_8_8_390,process.pDoubleTkMuPuppiHT_3_3_300,process.pDoubleTkMuPuppiJetPuppiMet_3_3_60_130,process.pDoubleTkMuon15_7,process.pDoubleTkMuonTkEle5_5_9,process.pDoubleTkMuon_4_4_OS_Dr1p2,process.pDoubleTkMuon_4p5_4p5_OS_Er2_Mass7to18,process.pDoubleTkMuon_OS_Er1p5_Dr1p4,process.pIsoTkEleEGEle22_12,process.pNNPuppiTauPuppiMet_55_190,process.pPuppiHT400,process.pPuppiHT450,process.pPuppiMET200,process.pPuppiMHT140,process.pPuppiTauTkIsoEle45_22,process.pPuppiTauTkMuon42_18,process.pQuadJet70_55_40_40,process.pSingleEGEle51,process.pSingleIsoTkEle28,process.pSingleIsoTkPho36,process.pSinglePuppiJet230,process.pSingleTkEle36,process.pSingleTkMuon22,process.pTkEleIsoPuppiHT_26_190,process.pTkElePuppiJet_28_40_MinDR,process.pTkEleTkMuon10_20,process.pTkMuPuppiJetPuppiMet_3_110_120,process.pTkMuTriPuppiJet_12_40_dRMax_DoubleJet_dEtaMax,process.pTkMuonDoubleTkEle6_17_17,process.pTkMuonPuppiHT6_320,process.pTkMuonTkEle7_23,process.pTkMuonTkIsoEle7_20,process.pTripleTkMuon5_3_3,process.user_step,process.endjob_step,process.NANOAODoutput_step)
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)
 


### PR DESCRIPTION
Changes L1nano table producers to move away from `SimpleCandidateFlatTableProducer` were needed following changes in CMSSW. 

In general if `SimpleCandidateFlatTableProducer` can still be used, it is, else `SimpleTriggerL1CandidateFlatTableProducer` is used (based on `l1t::L1Candidate`) for the nano tables and `SimpleP2GTCandidateFlatTableProducer` is used (based on `l1t::P2GTCandidate`) for the GT tables. If the `L1Candidate` or `P2GTCandidate` producers aren't possible then more dedicated producers are added on a case-by-case basis. 

In some cases `singleton` wasn't available with the new producer class so this has been commented out (although in these cases the option was false anyway), and several P2GT methods have new names that are now updated. In addition, some tables that previously were clones of others had to be made separate as they required a different producer to the table they were cloned from.